### PR TITLE
docs: v1 rebuild spec (requirements, design, tasks)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,65 @@
+# LGTM
+
+Reviewing pull requests with AI assistance while a human keeps final say. In scope: watching repositories, producing review findings locally, and gating what reaches the code host. Out of scope: writing code, merging, and anything that publishes without a human action.
+
+## Glossary
+
+### Forge
+
+A code host that owns pull requests, such as GitHub. LGTM speaks to exactly one Forge per repository and treats it as the system of record for PRs and reviews.
+
+### Watcher
+
+The long-running process that periodically asks each watched repository's Forge for open pull requests and decides what to do with each one. The Watcher observes and classifies; it never writes to the Forge.
+
+### WatchList
+
+The set of repositories the Watcher polls. A repository is either on the WatchList or invisible to LGTM; there is no partial watching.
+
+### AutoClassPr
+
+An open pull request that qualifies for review without being asked: the user authored it, or was requested as reviewer, assigned, or mentioned in its title or description. Auto-classification is what makes LGTM proactive rather than a tool you must remember to invoke.
+
+### TriagePr
+
+Any open pull request in a watched repository that is not an AutoClassPr. It waits for a human decision, review or skip, and nothing happens to it until that decision is made.
+
+### Skip
+
+The sticky decision that a TriagePr will not be reviewed. New activity on the pull request does not undo a Skip; only the human does.
+
+### Backfill
+
+The triage pass over pull requests that were already open when a repository joined the WatchList. Backfill always asks; automatic classification applies only to activity that happens after watching begins.
+
+### Agent
+
+A named reviewer definition the user can edit: which Provider runs it, how it behaves, and what extra instructions it carries. One Agent produces one set of findings per Round. Distinct from Provider, which is the thing that executes.
+
+### Provider
+
+The mechanism that actually performs a review, an AI tool already installed and authenticated on the user's machine. LGTM delegates to Providers rather than implementing review itself.
+
+### Round
+
+One review pass over one pull request at one specific head commit, by one Agent. New commits start a new Round; Rounds are never edited after the fact.
+
+### Finding
+
+A single reviewer observation: a location in the diff, a severity, and a comment. A Finding carries its own lifecycle state, open, discarded, posted, or held, and that state is the human's to change, not the Agent's.
+
+### Gate
+
+The human step between Findings on disk and anything reaching the Forge. The Gate is where the user discards junk and decides what posts. It is the product's defining boundary: LGTM without the Gate would be a bot.
+
+### DraftReview
+
+The review LGTM creates on the Forge: visible only to its author, editable comment by comment, and inert until the human submits it in the Forge's own interface. LGTM can create and delete a DraftReview but can never submit one.
+
+### QuotaGate
+
+The mechanism that pauses new review work when the user's AI subscription usage runs high, so LGTM never competes with the human for the same budget. Distinct from the Gate, which governs what leaves the machine; the QuotaGate governs what work starts.
+
+### Store
+
+The local, human-readable home of everything LGTM knows: watch state, Agents, Rounds, Findings. The Store is the source of truth; the Forge only ever sees what the Gate lets through.

--- a/docs/adr/0001-draft-only-posting.md
+++ b/docs/adr/0001-draft-only-posting.md
@@ -1,0 +1,24 @@
+# 0001. LGTM can create draft reviews but can never publish one
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+AI-generated review findings are worthless if teammates see them before a human edits them, and terminals are a bad place to read a diff. GitHub creates a review in PENDING state, visible only to its author and editable in GitHub's own UI, when the review-creation request omits the `event` field; there is no `draft: true` parameter, and including `event: "COMMENT"` publishes instantly and irreversibly. The old codebase guarded this with tests and kept one explicit submit command. During the v1 rebuild we had to decide whether that submit path survives.
+
+## Decision
+
+LGTM posts pending draft reviews and contains no code path that can publish one. There is no submit command, no function that sends an `event` field, and the forge adapter exposes no publishing operation. Submission happens exclusively in the forge's own UI, by the human.
+
+## Consequences
+
+The product's promise becomes structural instead of guarded: the dangerous request cannot be constructed, which is a stronger claim than "one careful function sends it". Tests shrink to asserting an absence. The user finishes every review in GitHub's editor, which is where they were going anyway to edit wording.
+
+Harder: no future automation can submit on the user's behalf without revisiting this decision, including innocuous flows like auto-approving trivial dependency bumps. Because the REST API cannot append to a pending review, updating a draft means deleting and recreating it. And the safety property depends on the forge adapter staying the only module that talks to the forge; a second HTTP client bypasses the whole design.
+
+## Alternatives considered
+
+**Keep a submit command** (the old design). Rejected: submission is the one thing the forge UI does strictly better, and keeping the command means keeping, guarding, and testing the only dangerous line in the codebase forever.
+
+**Post published comments directly with rate-limited pacing.** The original pre-pivot design, already deleted once. Rejected: it makes the human gate advisory instead of structural, and the entire product exists because that model fails.

--- a/docs/adr/0002-delegate-reviews-to-installed-clis.md
+++ b/docs/adr/0002-delegate-reviews-to-installed-clis.md
@@ -1,0 +1,24 @@
+# 0002. Reviews are delegated to AI CLIs the user already has installed
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+LGTM needs an LLM to review diffs, and its users are developers who already pay for AI coding tools with subscriptions (Claude Max, ChatGPT). Those tools ship their own review commands, manage their own authentication, and forbid third parties from extracting their subscription tokens. Implementing review against a raw completions API would mean owning prompts, API keys, and billing that the user already has covered.
+
+## Decision
+
+LGTM spawns the AI CLI the user already has installed and authenticated, as a subprocess, and prefers the CLI's built-in review command with the user's instructions appended. The user's own prompt lives in an editable agent file; LGTM never reads or extracts the CLI's credentials. v1 supports the Claude CLI only, behind a provider interface that admits others by configuration.
+
+## Consequences
+
+The user's existing subscription does the work: no API keys to manage, no second bill, and review quality rides on the vendor's own review skill, which improves without LGTM shipping anything. Auth stays where it belongs, in the CLI's keychain.
+
+Harder: CLI output formats are undocumented and drift between versions, so LGTM carries a deliberately tolerant multi-strategy parser and can still lose findings from a badly behaved release. Headless spawning inherits sharp edges: bare PATH under launchd, subprocesses that hold pipes open, and review consuming the same subscription quota the user works with interactively, which forced the quota gate into the design. LGTM also cannot tune model parameters directly; it gets whatever the CLI's review command does.
+
+## Alternatives considered
+
+**Direct API integration** (OpenRouter, Ollama, raw Anthropic API), which the old codebase supported. Rejected for v1: it makes LGTM own the review prompt, keys, and cost, reimplementing a worse version of what the CLIs already do; the old code itself concluded this was strictly worse.
+
+**Extracting credentials from the CLIs' keychains or config files**, which an early version of the old codebase attempted. Rejected outright: vendors explicitly forbid it, and it breaks silently when they rotate storage.

--- a/docs/adr/0003-daemon-plus-local-web-ui.md
+++ b/docs/adr/0003-daemon-plus-local-web-ui.md
@@ -1,0 +1,26 @@
+# 0003. Delivery is a local daemon with a web UI; a native tray shell comes later
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+The v1 rebuild replaces a terminal UI that was a bad surface for reading findings. The replacement had to keep everything local (the providers are CLIs on the user's machine), give a solo macOS developer a shippable v1 in weeks, and provide ambient awareness for a background tool whose worst failure is dying silently. Three designs were developed independently and judged: a pure local web app, a native menu-bar app (Tauri), and a hybrid. Apple's rules shaped the trade-off: `.app` bundles require Developer ID signing and notarization, while plain binaries installed via curl or brew face no Gatekeeper friction at all.
+
+## Decision
+
+One compiled binary runs a background daemon (watcher, HTTP API, embedded web UI on 127.0.0.1) owned by launchd, with best-effort native notifications fired by the daemon itself. A thin signed menu-bar shell arrives in v1.1, consuming the same status API the daemon exposes from day one. Ollama, Syncthing, and Docker Desktop all converged on this shape: daemon binds localhost, UI is disposable, tray is thin status.
+
+## Consequences
+
+The product iterates as an unsigned binary indefinitely; Apple bureaucracy only ever touches a small shell that rarely changes. launchd owning the daemon means reviewing continues when every UI is closed, and any UI can crash without consequence. The API contract doubles as the tray contract, so v1.1 needs no daemon changes.
+
+Harder: until the tray exists, a dead daemon is only visible by pulling (a status command, an open tab), which is the design's known weak spot and the reason the tray is scheduled rather than hypothetical. Notifications from a bare daemon are second-class on macOS. The daemon must solve launchd's bare-PATH problem to spawn user-installed CLIs at all.
+
+## Alternatives considered
+
+**Native menu-bar app owning everything** (Tauri tray + webview + sidecar). Best day-one ambient UX, rejected because signing, sidecar entitlements, and a Rust shell land in the v1 critical path of a solo TypeScript developer, and because tying the watcher's lifetime to a GUI process means quitting the tray silently stops reviewing.
+
+**Pure local web app with no native ambitions.** Fastest to ship and nearly identical to what v1 builds, rejected as an end state because its own mitigation for silent daemon death was to add a tray later, which is this decision without the prepared contract.
+
+**Hosted service or GitHub App.** Rejected: a server cannot spawn the user's local CLIs or reuse their subscriptions, and holding user tokens server-side inverts the local-first trust model.

--- a/docs/adr/0004-markdown-store.md
+++ b/docs/adr/0004-markdown-store.md
@@ -1,0 +1,24 @@
+# 0004. State lives in markdown files with frontmatter, not a database
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+The rebuild adds a web UI and an HTTP API, which is normally the moment a tool graduates to SQLite: queries, transactions, and no parsing. The old codebase stored everything as markdown with YAML frontmatter in a single directory, and the user named that property as one worth keeping: findings they can grep, read, and hand-edit in an editor, files that survive any rewrite of the tool around them.
+
+## Decision
+
+The store stays markdown plus frontmatter in one central directory: watch state, agent definitions, per-round findings with their lifecycle state in frontmatter. The daemon is the only writer; UI and CLI mutate through its API, and the daemon watches the directory so deliberate hand-edits show up live.
+
+## Consequences
+
+Every piece of state is inspectable and repairable with a text editor, diffable, and portable to whatever replaces this implementation. Review artifacts read as documents, which suits what they are. Debugging is `grep`, not a database client.
+
+Harder: no transactions and no queries, so consistency rests on conventions the code must honor (single writer, full finding keys, one file per round), and the old codebase's history shows what happens when they slip, including a real cross-round corruption bug. Listing views re-parse files instead of querying indexes, which sets a practical ceiling on scale that a personal tool fits under but a team product would not.
+
+## Alternatives considered
+
+**SQLite.** Better queries, real transactions, one-file portability. Rejected because it makes the store opaque to the user, and the store being readable is a feature of the product, not an implementation detail. The scale that would force the issue is out of scope for v1.
+
+**Markdown for artifacts plus SQLite for state.** Rejected: two sources of truth that can disagree, for a data volume that does not need the second one.

--- a/docs/adr/0005-poll-github-not-webhooks.md
+++ b/docs/adr/0005-poll-github-not-webhooks.md
@@ -1,0 +1,24 @@
+# 0005. The watcher polls the forge; there are no webhooks
+
+- **Status:** Accepted
+- **Date:** 2026-08-29
+
+## Context
+
+A PR watcher wants push notifications, and GitHub offers them, but only to a public HTTPS endpoint. LGTM's daemon runs on a laptop behind NAT with no inbound reachability, and GitHub has no public streaming API for repository events. Reaching webhook delivery from a home machine means standing infrastructure: a tunnel or relay that must itself stay alive, be secured, and be explained to users.
+
+## Decision
+
+The watcher polls each watched repository on an interval (15 minutes by default), using conditional requests so that unchanged repositories cost nothing against the API rate limit. Latency of one interval is accepted as the price of having no infrastructure.
+
+## Consequences
+
+Zero infrastructure: nothing to host, tunnel, register, or keep alive, and the tool works on any network. Conditional requests make the steady state nearly free, since a not-modified response costs no rate limit; the budget of five thousand requests per hour dwarfs what a personal watch list consumes.
+
+Harder: a new PR waits up to one interval before LGTM notices, which rules out any future where a review is expected within a minute of opening. Polling wakes up to find nothing most of the time, and per-PR detail fetches for triage metadata must be budgeted deliberately because only the list call gets the cheap conditional path.
+
+## Alternatives considered
+
+**Repository webhooks via a relay** (smee, a tunnel, or a small hosted forwarder). Real push latency, rejected because the relay is standing infrastructure with its own failure modes and trust surface, unjustifiable for a local-first personal tool. Revisit if a team deployment ever needs sub-minute latency.
+
+**The forge's notifications feed as a poll target.** A second polling surface with its own semantics and staleness quirks, rejected because it adds a subsystem without removing the poll loop.

--- a/docs/spec/decisions.md
+++ b/docs/spec/decisions.md
@@ -1,0 +1,60 @@
+# LGTM v1 decision log
+
+Date: 2026-08-29
+The record of the requirements session behind [requirements.md](requirements.md). The spec states outcomes; this file keeps the reasoning, so none of it gets re-litigated from scratch. Format per entry: what was decided, then why.
+
+## Delivery mechanism
+
+**Decided: hybrid, staged.** A Bun daemon with a localhost web UI ships in v1; a thin signed Swift menu-bar shell follows in v1.1 against the same status API.
+
+Three designs were developed independently (local web app, native menu-bar app in Tauri, hybrid) and scored by two judges with different mandates. Both picked the hybrid. The native app lost because macOS notarization, sidecar signing, and a Rust shell land in the v1 critical path for a solo TypeScript developer, and because a tray-owned watcher dies when the tray quits. The pure web app lost the tiebreak because a dead daemon is silent in that shape, and its own contingency plan was to grow a tray, which is the hybrid. Prior art (Ollama, Syncthing, Docker Desktop) converges on the same split: daemon binds 127.0.0.1, UI is disposable, tray is thin status.
+
+Consequences kept in the spec: plain compiled binaries skip Gatekeeper, so Apple signing only ever touches the small v1.1 shell; launchd owns the daemon so every UI is optional; the status API is shaped as the tray's contract from day one.
+
+## Scope
+
+**Watch + review + post.** No verification passes over posted findings in v1. Re-review on new commits injects prior findings as do-not-repeat context, which is a prompt block, not the verify machinery.
+
+**One agent, the Claude CLI.** codex is a v1.x configuration addition behind the same provider interface. Multi-agent orchestration and cross-agent dedup wait until a second agent exists.
+
+**No submit path at all.** The old `review submit` command is not ported. GitHub's UI does submission better, and a codebase with zero publish-capable code paths is a stronger claim than one guarded publish path.
+
+**Forge-agnostic later, GitHub-only now.** A `ForgeAdapter` interface is the seam; GitLab's draft-note model differs enough that the adapter boundary is where that difference will live.
+
+**Manual watch list.** Disk discovery dies; it was the buggiest old subsystem and answered the wrong question (what is on disk versus what is on GitHub). A GitHub-API repo picker is deferred.
+
+## Triage model
+
+**Auto-review classes: own PRs, requested reviewer, assignee, @mention in title or description.** Everything else in a watched repo waits in a triage inbox for a manual skip-or-review call. Comment-mention scanning and the notifications API are deferred until real mentions get missed.
+
+**Drafts hold until ready**, with a manual override. Reviewing WIP burns quota on code the author knows is unfinished.
+
+**Skip is sticky.** New commits do not resurrect a skipped PR; a skipped filter with unskip keeps it one click away. Resurrection would turn skip into snooze.
+
+**Backfill asks.** Adding a repo lists its open PRs with author, size, age, conflict and CI state; auto-class rows arrive pre-selected but nothing runs until confirmed. Auto rules apply only to activity after watching begins.
+
+## Quota
+
+**Gate on real usage, not estimates.** `claude -p "/usage"` was verified live: non-interactive, zero tokens and turns consumed, roughly four seconds, and it returns the same window percentages as the /usage screen. Defaults: pause new dispatches above 70% of the highest window, resume below 60% or on a parsed reset. The output format is undocumented, so the parser fails closed into a daily-cap fallback (20 runs) with the active mode logged. Richer local estimation (ccusage-style) was considered and deferred; the cap is the actual safety mechanism.
+
+**Pacing: 15-minute poll, two concurrent provider runs, 10-minute per-run timeout.** Configured in one file, no flag zoo.
+
+## Store and stack
+
+**Markdown plus frontmatter stays.** Human-readable, greppable, portable was a stated requirement. Same `~/.lgtm-farm/` root, new nested layout, no migration; old review dirs are transient artifacts, not data.
+
+**Bun >= 1.3.13, React 19, shadcn/ui, Tailwind v4.** shadcn was requested so the UI is mostly stock components. Verified constraints: production builds must use the `Bun.build()` JS API because the CLI ignores bundler plugins and emits an unstyled binary, and the 1.3.13 floor exists because the Tailwind-mangling `@layer` bug was a 1.3.0 regression fixed there.
+
+**Polling, not webhooks.** GitHub webhooks require a public HTTPS endpoint a home daemon does not have, and no public streaming API exists. Conditional requests make polling nearly free (a 304 costs no rate limit). A webhook relay is deferred to a hypothetical team setup.
+
+## Process
+
+**Clean-slate `v2` branch.** First commit removes everything except LICENSE and .gitignore, including all of `.kiro/`. Old code stays reachable on `main` as the porting reference; dead code living alongside new code is how the last codebase grew three repo registries.
+
+**Battle-tested modules port with their tests.** Diff parser, tolerant output parser, draft-review poster, finding-key rules, frontmatter layer. The spec's ported-modules table carries exact old paths and test counts.
+
+**Spec-first, in `docs/spec/`.** The old repo's own history showed specced features holding up best; only the Kiro branding goes.
+
+## Verification carried into the spec
+
+An adversarial review pass (four critics: decision fidelity, technical claims, consistency, style) ran before sign-off and fixed 48 findings, including five design blockers: held findings that could never be posted again, a pending-review id that was never cleared after submission, an unreachable draft-to-ready transition, unretryable failed rounds with no crash recovery, and closed/reopened PRs having no representation. The remaining known unknown is deliberate: whether `claude -p` with the bundled review command works from a directory outside any checkout is the first M0 task, because the old code always ran inside a local clone and v1 has no clones.

--- a/docs/spec/decisions.md
+++ b/docs/spec/decisions.md
@@ -1,7 +1,7 @@
 # LGTM v1 decision log
 
 Date: 2026-08-29
-The record of the requirements session behind [requirements.md](requirements.md). The spec states outcomes; this file keeps the reasoning, so none of it gets re-litigated from scratch. Format per entry: what was decided, then why.
+The record of the requirements session behind [requirements.md](requirements.md). The spec states outcomes; this file keeps the reasoning, so none of it gets re-litigated from scratch. Format per entry: what was decided, then why. The five decisions that are hard to reverse and the result of real trade-offs also have formal records in [docs/adr/](../adr/); the project glossary lives in [CONTEXT.md](../../CONTEXT.md).
 
 ## Delivery mechanism
 

--- a/docs/spec/design.md
+++ b/docs/spec/design.md
@@ -1,0 +1,299 @@
+# LGTM v1 design
+
+Status: draft for sign-off
+Date: 2026-08-29
+Companion to [requirements.md](requirements.md). Task order lives in [tasks.md](tasks.md).
+
+## Architecture
+
+One compiled Bun binary, three roles: a long-lived daemon, short-lived CLI invocations that talk to it over HTTP, and an embedded SPA it serves.
+
+```mermaid
+flowchart LR
+    subgraph daemon["lgtm up (daemon, launchd-owned)"]
+        sched[Scheduler<br/>15 min + wake + boot] --> cycle[Poll cycle]
+        cycle --> forge[ForgeAdapter<br/>GitHub REST, ETags]
+        cycle --> classify[Classifier<br/>auto-class / triage]
+        classify --> queue[Review queue<br/>concurrency 2]
+        quota[Quota gate<br/>claude -p /usage] --> queue
+        queue --> runner[Provider runner<br/>spawn claude CLI]
+        runner --> parser[Tolerant parser]
+        parser --> store[(~/.lgtm-farm<br/>md + frontmatter)]
+        store --> api[HTTP API + SSE<br/>127.0.0.1, bearer]
+        api --> notify[Notifier<br/>terminal-notifier / osascript]
+    end
+    spa[Embedded SPA<br/>React + shadcn] <--> api
+    cli[lgtm status / open / watch] <--> api
+    tray[v1.1 tray shell] -.-> api
+    post[Post gate action] --> forge
+```
+
+Single-writer rule: only the daemon writes the store. The SPA and the CLI mutate through the API. The daemon also watches the store directory with `fs.watch` so hand-edits show up in the UI without a restart.
+
+## Store layout
+
+```
+~/.lgtm-farm/
+  token                           # bearer token, created at first run, mode 0600
+  daemon.json                     # ephemeral rendezvous: {port, pid, startedAt}, mode 0600,
+                                  #   rewritten at boot when the recorded pid is dead
+  config.md                       # frontmatter: interval_minutes, pause_above_pct,
+                                  #   resume_below_pct, daily_cap, concurrency, and manual
+                                  #   binary pins (claude_path, gh_path); a pin skips the probe
+  watch.md                        # frontmatter list: {owner, repo, addedAt, lastPolledAt, etag}
+  agents/
+    reviewer.md                   # frontmatter: provider, timeout_minutes, severity_floor, enabled
+                                  # body: the review prompt, appended to the CLI's built-in /review
+  templates/
+    review-body.md                # post body template with placeholders
+  reviews/<owner>/<repo>/pr-<n>/
+    meta.md                       # frontmatter below
+    diff-<sha>.patch              # diff snapshot per reviewed head SHA, written when a
+                                  #   round completes; finding cards slice hunks from
+                                  #   their round's own SHA, GitHub link as fallback
+    r<N>-<agent>.md               # one file per round per agent, frontmatter below
+    r<N>-<agent>.raw.txt          # only when parsing failed
+  logs/
+    daemon.log                    # rotating, plain text
+```
+
+`meta.md` frontmatter:
+
+```yaml
+owner: acme
+repo: api
+number: 42
+url: https://github.com/acme/api/pull/42
+title: Add rate limiter
+author: pszf11235
+state: reviewed          # triage | skipped | queued | reviewing | reviewed | failed | closed
+classification: own      # own | requested | assigned | mentioned | manual | none
+draft: false
+headSha: abc123
+lastReviewedSha: abc123
+failedAttempts: 0        # retry counter per head SHA, reset on new commits
+rounds: 2
+pendingReviewId: 987654  # set while a draft exists on GitHub; cleared when getReview
+                         #   reports it is no longer pending
+closedAt: null
+updatedAt: 2026-08-29T10:00:00Z
+```
+
+`r<N>-<agent>.md` frontmatter holds the canonical findings array; the markdown body is a generated human-readable rendering of the same data:
+
+```yaml
+round: 2
+agent: reviewer
+provider: claude-cli
+status: ok               # ok | failed. A failed round still writes this file, with an
+                         #   empty findings array, next to its .raw.txt, and round
+                         #   numbers stay monotonic across failures
+headSha: abc123
+startedAt: ...
+durationMs: 84210
+findings:
+  - id: f1
+    severity: high        # after applying the agent's severity floor
+    file: src/limiter.ts
+    line: 118
+    comment: "..."
+    suggestion: "..."     # optional
+    state: open           # open | discarded | posted | held
+    heldReason: null      # set when state is held
+```
+
+Finding identity everywhere is `r<N>:<agent>:<id>`, printed as `r2:reviewer:f1`, and this is the one canonical form across store, API, and UI. Ids restart at f1 per round file; the old codebase corrupted rounds by matching bare ids, and its fix (key on the full triple) is carried over as a rule, with tests.
+
+Frontmatter is parsed with gray-matter behind a `structuredClone` guard, because gray-matter memoizes and returns shared data objects. This bit the old codebase; the guard and its test port over.
+
+## Poll cycle
+
+Per watched repo, per cycle:
+
+1. `GET /repos/{o}/{r}/pulls?state=open` with the stored ETag. A 304 ends the repo's cycle at zero rate-limit cost.
+2. For each open PR, compare against `meta.md`:
+   - Unknown PR: classify. Auto-class and not draft: state `queued`. Auto-class draft: state `triage` with a "reviews when ready" marker and the classification recorded. Otherwise: state `triage`.
+   - Known PR whose draft flag flipped from true to false: queue it when it is auto-class (or was approved manually) and its head SHA has no completed round. A SHA already reviewed through "review anyway" does not queue again.
+   - Known PR, `headSha` unchanged: re-queue when state is `failed` and `failedAttempts` is below 3; otherwise no action.
+   - Known PR, new `headSha`: if `reviewed` or `failed` and auto-class or previously approved manually, re-queue for a fresh round with `failedAttempts` reset; if `skipped`, stay skipped; if `triage`, refresh metadata.
+   - PR no longer open: state `closed`, `closedAt` stamped, hidden from active views. On reopen, a previously `skipped` PR stays skipped; anything else resumes as a known PR under the rules above, keeping its rounds, findings, and any `pendingReviewId`.
+   - PR with a recorded `pendingReviewId`: check it via `getReview`; when the review is no longer pending (submitted in GitHub's UI, or deleted), clear the field so the next post is not refused.
+3. Drain the review queue through the quota gate and the concurrency cap. The queue holds at most one entry per PR, and a newer head SHA replaces a queued entry. An in-flight round is never cancelled; it completes, records the SHA it reviewed, and the PR re-queues for the newer SHA. One PR never has two rounds running at once.
+
+At boot, and whenever `daemon.json` names a dead pid, the daemon rewrites `daemon.json` and resets any meta stuck in `queued` or `reviewing` back to `queued`, so a crash never strands a PR.
+
+Classification reads the PR list item: `user.login` (own), `requested_reviewers` (requested), `assignees` (assigned), `@login` in title or body (mentioned). The authenticated login comes from `GET /user`, fetched once and cached.
+
+Triage metadata (additions, deletions, changed files, mergeable state) needs the per-PR detail endpoint, so the daemon fetches it only for PRs entering triage or the backfill list, not on every cycle. CI status is one `GET /commits/{sha}/check-runs` per triage PR; this reads the Checks API only, so CI reporting through the legacy commit Status API renders as "no checks" in v1. GitHub computes `mergeable` asynchronously; a null value renders as "computing", not as a failure.
+
+Scheduler: one cycle at daemon start, then a 15-minute timer with small jitter. Timers do not fire during sleep, so the daemon subscribes to wake notifications and runs a catch-up cycle on wake. An in-flight guard prevents overlapping cycles (a real bug in the old watcher).
+
+## Review execution
+
+The daemon spawns the provider CLI directly. The old codebase's self-invoking `internal-worker` process layer existed to isolate multiple agents; with one agent whose CLI is already a subprocess, v1 drops that layer.
+
+One inherited assumption needs proof before anything builds on it. The old code always spawned the CLI inside a local checkout, while v1 has no clones, so the M0 spike runs the bundled review command against a full PR URL from a neutral working directory on the pinned CLI version (2.1.233 or later; earlier versions break bundled slash commands in print mode) and confirms the findings survive the parser.
+
+When a round completes, the daemon fetches the PR diff at the reviewed SHA and stores it as `diff-<sha>.patch` in the PR dir, the source for hunk slicing on finding cards.
+
+The spawn pattern ports from the old `providers.ts` unchanged in spirit: drain stdout and stderr incrementally, race the timeout against the read, SIGKILL on deadline, salvage partial stdout. Grandchild processes inherit the stdout pipe and can hold it open past the child's death; the race is what makes the timeout real.
+
+Prompt assembly:
+
+```
+/review <prUrl>
+
+Additional instructions:
+<body of agents/reviewer.md>
+
+<if prior rounds exist>
+Already raised in earlier reviews. Verify silently; do not repeat:
+- src/limiter.ts:118 [high] <comment>   (r1:reviewer:f3)
+...
+
+Respond with JSON only: {"findings":[{"file","line","severity","comment","suggestion"}]}
+```
+
+Output goes through the ported `extractFindings` chain (bare JSON, wrapped keys, fenced blocks, CLI envelope unwrap, embedded-JSON scan, prose regex) and `validateFindings` (key and severity aliases, path prefix stripping, severity floor, drop counting). Unparseable output lands in `r<N>-<agent>.raw.txt` and the round records `state: failed`; the PR stays un-reviewed so the next cycle retries.
+
+## Quota gate
+
+Source of truth: `claude -p "/usage"`, spawned with the resolved absolute path. Verified behavior: non-interactive, no tokens or turns consumed, roughly 4 seconds, output like:
+
+```
+Current session: 61% used · resets Aug 29 at 3:40pm (Europe/Paris)
+Current week (all models): 56% used · resets Aug 29 at 8pm (Europe/Paris)
+```
+
+The parser regexes `(\d+)% used` per line and takes the maximum across all reported windows. It also extracts each line's reset time where it can (day, clock time, timezone name; the string carries no year, so the next matching occurrence applies). Percentages are the contract; reset times are best-effort, and when only the percentages parse the gate runs percentage-only and leaves `throttled` through hysteresis alone. The format is not documented, so the parser fails closed into fallback mode rather than misreading.
+
+State machine:
+
+- `ok`: max window below `resume_below_pct`, dispatch freely.
+- `throttled` entered when max window exceeds `pause_above_pct` (default 70); no new dispatches, queue holds. The pause notification fires once per throttled entry, deduped by the parsed reset timestamp when available and by the entry transition otherwise.
+- Exit `throttled` when max window drops below `resume_below_pct` (default 60) or a parsed reset time passes.
+- `fallback` entered when the usage output fails to parse twice in a row. The gate becomes a daily run counter against `daily_cap` (default 20). Every dispatch decision logs its mode.
+
+Probe cadence: before each dispatch if the cached reading is older than 3 minutes, plus a background refresh every 5 minutes while the queue is non-empty.
+
+## ForgeAdapter
+
+The only module allowed to speak to a code host. GitHub is the sole v1 implementation; the interface is the future GitLab seam.
+
+```ts
+interface ForgeAdapter {
+  listOpenPRs(repo: RepoRef): Promise<PRSummary[] | NotModified>;
+  getPR(ref: PRRef): Promise<PRDetail>;            // triage metadata
+  getDiff(ref: PRRef): Promise<string>;            // unified diff, current head
+  getCheckStatus(ref: PRRef, sha: string): Promise<CheckStatus>;
+  createDraftReview(ref: PRRef, review: DraftReview): Promise<{ id: number }>;
+  deleteDraftReview(ref: PRRef, id: number): Promise<void>;
+  getReview(ref: PRRef, id: number): Promise<"pending" | "submitted" | "gone">;
+  authenticatedUser(): Promise<string>;
+}
+```
+
+Deliberate absences, enforced by tests as in the old codebase: no function submits, publishes, or sends an `event` field. `createDraftReview` builds its request from a function whose test asserts `"event" in body === false`, throws unless the response state is `PENDING`, and refuses an empty comment list.
+
+Posting flow (`POST /api/prs/:ref/post`):
+
+1. If `pendingReviewId` is set, check it via `getReview`. No longer pending: clear the field and continue. Still pending: refuse, unless the recreate flag is passed. Recreate deletes the old draft (`DELETE`, 404 tolerated), clears the field, and flips that draft's `posted` findings back to `open`, since their comments left GitHub with the draft.
+2. Re-fetch the current diff. Build `Map<file, Set<rhsLine>>` of added and context lines with the ported diff parser.
+3. Validate every `open` and `held` finding. A finding that validates is included, so a held one returns to play automatically. A miss becomes or stays `held` with a reason, disclosed in the body and retried at the next post.
+4. When zero findings validate, abort before any GitHub call and return the per-finding held reasons. No body-only review is created.
+5. Render `templates/review-body.md` (placeholders: counts by severity, agent list, held list), apply any inline edits from the confirm pane.
+6. One `POST .../reviews` with no event key. Assert `PENDING`. Record `pendingReviewId`, mark the included findings `posted`.
+7. Dry-run performs steps 2 to 5 and returns the exact request body, writing nothing anywhere.
+
+Token resolution: `GITHUB_TOKEN`, `GH_TOKEN`, `gh auth token` (spawned by absolute path, stderr discarded), then `~/.lgtm-farm/credentials.json` (0600). Re-resolved on any 401, not cached for the daemon's lifetime.
+
+## HTTP API
+
+Bun.serve, bound explicitly to 127.0.0.1, default port 4747, scan to 4757 on conflict after probing `/api/health` for an LGTM signature to distinguish a stale daemon from a foreign process.
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/` | GET | SPA shell (embedded), unauthenticated |
+| `/api/health` | GET | `{app:"lgtm", version, pid}`, unauthenticated |
+| `/api/status` | GET | The tray contract: daemon uptime, last cycle time and outcome per repo, queue length, quota state and mode, provider and token detection, counts awaiting gate and triage |
+| `/api/events` | GET | SSE stream; accepts `?token=` since EventSource cannot set headers |
+| `/api/prs` | GET | PR list with state, classification, triage metadata; filters by state |
+| `/api/prs/:owner/:repo/:number/decision` | POST | `{action: "review" \| "skip" \| "unskip" \| "review-anyway"}` |
+| `/api/prs/:owner/:repo/:number/findings` | GET | Rounds and findings, hunks sliced from the stored `diff-<sha>.patch` of each finding's round, GitHub link as fallback when the snapshot is missing |
+| `/api/prs/:owner/:repo/:number/findings/:key` | PATCH | `{state: "discarded" \| "open"}`, key in the canonical `r2:reviewer:f1` form |
+| `/api/prs/:owner/:repo/:number/validate` | POST | Dry-run line validation, per-finding verdicts |
+| `/api/prs/:owner/:repo/:number/post` | POST | `{body?, recreate?, dryRun?}`, returns per-finding results |
+| `/api/watchlist` | GET/POST/DELETE | Manage watched repos. POST writes triage-state meta entries for every open PR before the repo joins the polled set (so nothing auto-queues ahead of the backfill confirm), then returns the backfill list with metadata and pre-selection; the confirm pane issues one decision call per selected PR. DELETE hides the repo's PRs from active views and keeps the on-disk tree |
+| `/api/config` | GET/PATCH | Read and update config.md fields |
+
+Auth: every `/api/*` route except `/api/health` requires `Authorization: Bearer <token>` (or the SSE query token). The token is a random 32 bytes generated at first run and stored in its own `token` file (0600), so it survives daemon restarts; `daemon.json` carries only port, pid, and start time. `lgtm open` launches `http://127.0.0.1:<port>/#t=<token>`; the SPA moves it to localStorage and strips the fragment with `history.replaceState`. A request with a bad token gets a page-level "run lgtm open to reauthenticate" response, not a bare 401. Host header must be `127.0.0.1:<port>` or `localhost:<port>` (kills DNS rebinding); mutating routes also require a matching Origin. No CORS headers are set.
+
+SSE events: `cycle-finished`, `pr-changed`, `findings-ready`, `quota-changed`, `error`. The SPA treats every event as an invalidation hint and refetches; events carry ids, not payloads, so the API stays the single source of truth.
+
+## Web UI
+
+Stack: React 19, shadcn/ui (new-york), Tailwind v4. Scaffolded from `bun init --react=shadcn`, which wires `components.json`, Radix, the Tailwind plugin, and `@/*` paths. Components come from `bunx shadcn add`; custom code is layout and the finding card.
+
+Views:
+
+- **Inbox**: triage PRs (skip / review buttons, metadata line), PRs with ungated findings (finding count by severity, jump to detail), and a collapsed skipped section with unskip buttons. The empty state doubles as a health check showing watcher liveness and next poll time.
+- **PR detail**: header (title, author, classification badge, head SHA, GitHub link), finding cards grouped by file. Card: severity chip, `file:line`, comment, suggestion block, sliced diff hunk (about 10 lines, server-rendered from the ported diff parser), discard button, GitHub deep link. Footer: "Post draft (n findings)" opening the confirm pane (editable body, held-back list), then per-finding results and "Open pending review on GitHub".
+- **Repos**: watch list with last-poll time, add field (`owner/repo`), remove. Adding opens the backfill pane: open PRs with metadata, auto-class rows pre-checked, one confirm.
+- **Settings**: provider and gh detection with resolved paths and manual pins, token status, quota thresholds, interval, daemon info.
+
+Keyboard: `j`/`k` between cards, `d` discard, `enter` confirm. Nothing else in v1.
+
+## Notifications
+
+A small notifier module in the daemon, called by the event bus with dedup rules from R8 (once per distinct error cause; one 4-hour reminder for ungated findings; everything else once).
+
+Transport probe order: `terminal-notifier` (resolved like other binaries; supports `-open` deep links into the UI) then `osascript display notification` (no click action) then silence with a log line. The notifier is fire-and-forget; failures never affect the pipeline.
+
+## Daemon lifecycle
+
+- `lgtm up`: foreground daemon. Writes `daemon.json` on bind, removes it on clean exit, and overwrites it at boot when the recorded pid is dead.
+- `lgtm install`: writes `~/Library/LaunchAgents/com.lgtm.daemon.plist` (`KeepAlive`, recognizable label since macOS surfaces it in Login Items) and runs `launchctl bootstrap gui/$UID` plus `kickstart`. No sudo. `lgtm uninstall` runs `bootout` and removes the plist.
+- Binary path resolution at boot: run `$SHELL -l -c 'command -v claude gh terminal-notifier'`, keep the resolved absolute paths in memory, re-probe on ENOENT at spawn time, and surface all results in `/api/status`. Manual pins in `config.md` (`claude_path`, `gh_path`) skip the probe for that binary, so a re-probe can never overwrite a deliberate choice.
+- Wake handling: subscribe to sleep/wake (via polling of a monotonic-vs-wall clock delta, or an IOKit notification if trivial to wire up); on wake, run a catch-up cycle.
+- Store lock: `daemon.json` holds the pid; a second `lgtm up` refuses to start if the pid is alive.
+
+## Build and distribution
+
+- Bun >= 1.3.13 required. The CSS `@layer` bug that mangles Tailwind v4 output was a 1.3.0 regression fixed in 1.3.13 (April 2026), so a plain 1.3.x floor would admit exactly the broken versions; this machine's 1.2.18 must be upgraded.
+- Dev loop: `bun --hot src/main.ts`, Bun.serve with `routes` and the HTML import; Tailwind via `bun-plugin-tailwind` configured in `bunfig.toml` `[serve.static]`.
+- Production: `bun run build.ts`, which calls the `Bun.build()` JS API with `compile: { outfile: "dist/lgtm" }` and the Tailwind plugin. Never the `bun build --compile` CLI. It ignores bundler plugins and produces an unstyled binary (open Bun bug).
+- Distribution v1: a GitHub release with the darwin-arm64 binary and a checksum. Plain binaries downloaded via curl carry no Gatekeeper burden. No brew tap, no signing, until after the dogfood period.
+
+## Ported modules
+
+| Old (main branch) | New home | Tests carried |
+|---|---|---|
+| `packages/plugins/review/src/domain/diff-parser.ts` | `src/core/diff.ts` (+ hunk slicing for cards) | 28 |
+| `packages/plugins/review/src/domain/providers.ts` (claude spawn, run pattern, extractFindings, validateFindings) | `src/provider/` | subset of 42 |
+| `packages/plugins/review/src/domain/pending-review.ts` minus submit | `src/forge/github/draft-review.ts` | 30 minus submit tests |
+| `packages/plugins/review/src/infra/github.ts` | `src/forge/github/adapter.ts` | 13 |
+| `packages/plugins/review/src/domain/review-store.ts` | `src/store/reviews.ts` (new layout, same finding-key rules) | 44, adapted |
+| `packages/plugins/review/src/domain/watch-cycle.ts` (`decidePR`) | `src/core/classify.ts` (extended for triage) | 18, adapted |
+| `packages/plugins/review/src/domain/pr-ref.ts` | `src/core/pr-ref.ts` | 19 |
+| `packages/core/src/store/okf.ts` (gray-matter + clone guard) | `src/store/okf.ts` | 8 |
+
+Everything else in the old tree is reference material, not a porting target.
+
+## Testing
+
+- Ported domain tests come with their modules and must pass before any new feature lands on top.
+- The no-publish invariant keeps its explicit tests: request builder emits no `event` key; the GitHub adapter exposes no submitting function.
+- The offline harness from the old TESTING.md ports over. A fake `claude` shim on PATH lets the full watch, review, gate, and dry-run-post loop run without network or quota.
+- The old removals audit and the final pre-submission review together yield a seven-item regression checklist; each item gets a test in the module it belongs to: a watch add through the API lands in `watch.md` and is polled on the next cycle, the interval default matches its documentation, missing binaries print nothing to stderr during detection, PR listing respects pagination, dry-run writes nothing, cache keys are repo-qualified, an all-failed round does not mark the PR reviewed.
+
+## Deferred decisions
+
+Recorded so they are not re-litigated silently:
+
+- Comment-mention detection (tier b) and the notifications API: revisit if real mentions get missed.
+- Cross-agent dedup: only when a second agent exists.
+- Repo picker backed by the GitHub API: v1 stays manual `owner/repo` entry.
+- Local usage estimation (ccusage-style) as a richer quota fallback: v1's fallback is the daily cap alone.
+- Legacy commit Status API as a CI-display supplement: v1 reads the Checks API only.
+- Webhook relay delivery: only if a team setup ever needs sub-minute latency.
+- Linux support: the daemon is portable; `install` needs a systemd variant.

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -1,0 +1,123 @@
+# LGTM v1 requirements
+
+Status: draft for sign-off
+Date: 2026-08-29
+Scope: the ground-up rebuild on the `v2` branch. This document supersedes every spec under the old `.kiro/` tree.
+
+## Premise
+
+AI coding agents let one developer open five PRs in an hour. A human still has to review them. LGTM watches your repositories, reviews new PRs by spawning the Claude CLI you already pay for, and writes the findings to disk. Nothing reaches GitHub until you post, and what posts is a PENDING draft review that only you can see, editable comment by comment in GitHub's own UI before you submit it there.
+
+v1 replaces the TUI with a local web UI served by a background daemon. A native menu bar shell follows in v1.1 and is out of scope here except for the API contract it will consume.
+
+v1 is built for one user on macOS. The repo stays public and the README stays honest, but there is no cross-platform work and no packaging polish until the tool has survived two weeks of daily use.
+
+## Definitions
+
+- **Forge**: a code host. v1 implements GitHub only, behind an adapter interface so GitLab and others can follow.
+- **Auto-class PR**: an open PR that qualifies for review without being asked: you authored it, or you are a requested reviewer, an assignee, or @-mentioned in its title or description.
+- **Triage PR**: any other open PR in a watched repo. It waits in the inbox for a manual decision: review or skip.
+- **Round**: one review pass over one PR at one head SHA, by one agent.
+- **Finding**: one reviewer observation with file, line, severity, comment, and optional suggestion. Findings carry their own state on disk: `open`, `discarded`, `posted`, or `held`.
+- **Gate**: the human step between findings on disk and a draft review on GitHub.
+- **Window**: a Claude subscription usage window (the 5-hour session window or a weekly window), reported by the CLI as a percentage used.
+
+## R1: Watching
+
+1. The daemon polls each watched repo for open PRs every 15 minutes by default. The interval is configurable in the store's config file, not by flags.
+2. A poll cycle runs immediately at daemon start and immediately after the machine wakes from sleep.
+3. The watch list is a single file, `watch.md`, keyed by `owner/repo`. There is no other repo registry.
+4. You add repos manually, by typing `owner/repo` in the web UI or running `lgtm watch add owner/repo`. Disk discovery does not exist in v1.
+5. Polling uses conditional requests (ETag) so unchanged repos cost no rate limit. GitHub offers no push channel a local daemon can receive without public infrastructure, so polling is the mechanism, not a placeholder for one.
+
+## R2: PR classification and triage
+
+1. On every cycle, each open PR is classified. Auto-class PRs are queued for review. All other PRs enter the triage inbox and wait.
+2. Mention detection covers requested reviewers, assignees, and `@login` in the PR title or description. Comment scanning and the notifications API are explicit non-goals for v1.
+3. A draft PR is never auto-reviewed. It is visible with a "reviews when ready" marker, and the review fires when it leaves draft state. A manual "review anyway" action overrides the hold.
+4. A triage decision is `review` or `skip`. Skip is sticky. New commits do not resurrect a skipped PR, and skipped PRs stay listed under a filter with an unskip action.
+5. The triage inbox shows, per PR: author, additions and deletions, files changed, age, mergeable state, and CI status for the head SHA.
+6. Adding a repo backfills its open PRs into the triage inbox with the same metadata. Auto-class PRs arrive pre-selected for review, and nothing runs until the selection is confirmed. Auto-classification of new activity begins only after the repo is watched.
+7. A closed or merged PR leaves the active views. Its on-disk review data is kept.
+
+## R3: Review execution
+
+1. v1 has one agent, the Claude CLI, spawned in print mode with its bundled review command and the user's prompt appended as additional instructions. The CLI version is pinned to 2.1.233 or later (earlier versions break bundled slash commands in print mode), and an M0 spike verifies the invocation from a directory outside any checkout before anything builds on it. The provider layer is an interface so codex and others can be added by configuration later, but no second provider ships in v1.
+2. The agent prompt lives in `agents/reviewer.md` in the store, an editable markdown file with frontmatter for provider, timeout, and severity floor. Editing it changes review behavior without a restart.
+3. At most 2 provider processes run at once, globally. Further work queues. Each run has a 10-minute timeout; on timeout the process is killed and partial output is salvaged.
+4. The tolerant multi-strategy parser ported from the old codebase normalizes agent output. Unparseable output is preserved next to the round file as `.raw.txt` and surfaces as a failed round, never as silently missing findings.
+5. A PR is not marked reviewed when its round failed. The next cycle retries it, up to 3 attempts per head SHA.
+6. When a reviewed PR gets new commits, the daemon runs a fresh round and injects the prior rounds' findings as "already raised, do not repeat" context. There is no verification pass over posted findings in v1.
+7. The review step and the watch step never write to GitHub.
+
+## R4: Quota gating
+
+1. Before dispatching a review, and on a background timer, the daemon reads real subscription usage via `claude -p "/usage"`, which is non-interactive and consumes no tokens or turns.
+2. The gate pauses new dispatches when the highest reported window percentage exceeds `pause_above_pct` (default 70) and resumes below `resume_below_pct` (default 60), or when a parsed window reset time passes. Queued work is kept, not dropped.
+3. When the usage output cannot be parsed (for example after a CLI update), the gate degrades to a hard daily run cap (default 20), and every gating decision logs which mode produced it. Richer local estimation is deferred.
+4. Quota state, mode, and any pause are always visible in the UI status area, and the first pause of a window fires a notification.
+
+## R5: Findings and the gate
+
+1. The findings view lists PRs with ungated findings, and per PR shows each finding as a card: severity, file and line, agent, comment, suggestion, and the surrounding diff hunk sliced server-side from the PR diff. Each card links to the file and line on GitHub.
+2. Discarding a finding flips its state in the round file's frontmatter. It is reversible and the finding remains on disk.
+3. There is no full diff viewer in v1. The hunk on the card plus the GitHub link is the reading surface before posting; GitHub's own UI is the surface after.
+
+## R6: Posting
+
+1. Posting collects the PR's open findings and creates one PENDING draft review on GitHub: `POST /repos/{owner}/{repo}/pulls/{n}/reviews` with a body and line comments and no `event` key. The response must come back in `PENDING` state or the operation fails loudly.
+2. The new codebase contains zero code paths that can publish a review. There is no submit command and no function that sends an `event` field. Submission happens in GitHub's UI. Tests assert this, as in the old codebase, and the absence of any event-sending function to guard strengthens it.
+3. Before posting, every finding's line is validated against the current diff, re-fetched at post time. Findings whose line no longer exists are marked `held` with a reason, disclosed in the review body, and retried automatically at the next post. GitHub rejects the whole request if one comment misses, so validation is a precondition, not politeness. When zero findings validate, the post aborts before any GitHub call.
+4. The post flow shows a confirm pane first: the auto-generated review body (finding counts by severity, agent attribution, held-back disclosure) rendered from an editable template at `templates/review-body.md`, editable inline before sending.
+5. One pending review per PR at a time. Posting over an existing draft is refused; a recreate action deletes the old draft and posts fresh, because the REST API cannot append to a pending review. When the recorded draft was already submitted or deleted on GitHub, LGTM detects that and clears its record instead of refusing forever.
+6. After posting, the UI shows per-finding results (posted, held with reason) and a link that opens the pending review on GitHub.
+7. A dry-run mode prints the exact request without writing to GitHub or to the store.
+
+## R7: Daemon and lifecycle
+
+1. Everything ships as one Bun-compiled binary, `lgtm`. `lgtm up` runs the daemon in the foreground; `lgtm install` writes and bootstraps a launchd LaunchAgent so the daemon survives reboots and crashes; `lgtm uninstall` removes it.
+2. The HTTP server binds 127.0.0.1 only. All `/api/*` routes require a bearer token generated at first run and stored with mode 0600. `lgtm open` launches the browser with the token in the URL fragment; the SPA stores it locally and strips it from the URL. Host and Origin checks reject DNS-rebinding and cross-site requests.
+3. The daemon resolves absolute paths to `claude` and `gh` at startup via a login-shell probe, caches them, re-probes when a spawn fails, and exposes the results in the status API. launchd gives daemons a bare PATH; this is a correctness requirement, not polish. A manual path override exists in settings for installs the probe cannot see.
+4. `lgtm status` reports daemon liveness, last cycle, queue, and quota from the API, and exits non-zero when the daemon is down.
+5. On a port conflict the daemon probes the occupant's health endpoint to distinguish a stale LGTM instance from a foreign process, then scans a small port range.
+6. GitHub auth resolves in order: `GITHUB_TOKEN` or `GH_TOKEN`, then `gh auth token` with stderr discarded, then a saved credential file. Missing auth produces guidance, not a stack trace.
+
+## R8: Notifications
+
+1. The daemon fires native macOS notifications for exactly four events: findings ready for gating, a new PR in triage, a watcher error that needs the user (dead token, missing or failing CLI), and a quota pause.
+2. Errors notify once per distinct cause, not once per cycle.
+3. If findings sit ungated for 4 hours, one reminder fires. No other repeats.
+4. Notifications are best-effort: terminal-notifier with a deep link into the web UI when available, osascript otherwise, silence when neither works. An open browser tab additionally receives live updates over SSE.
+
+## R9: Store
+
+1. The store lives at `~/.lgtm-farm/` as markdown files with YAML frontmatter, human-readable and greppable. Review data is under `reviews/<owner>/<repo>/pr-<n>/` with a `meta.md` and per-round `r<N>-<agent>.md` files.
+2. The old flat store layout is ignored. There is no migration; old review dirs simply stop being read.
+3. Finding identity is scoped `r<N>:<agent>:<id>`, for example `r2:reviewer:f1`, because ids restart per round file. Any state change addresses a finding by its full key.
+4. Only the daemon writes the store. UI and CLI mutate through the API. The daemon watches the store directory so hand-edits made in an editor are picked up and broadcast to the UI.
+5. Removing a repo from the watch list keeps its on-disk reviews; its PRs leave the active views. Re-adding reconciles against the existing files, so known PRs keep their state and backfill lists only unknown ones.
+
+## R10: Web UI
+
+1. The SPA is embedded in the binary and served by the daemon. It is built with React and shadcn/ui components so nearly all UI is assembled from stock parts.
+2. Views: an inbox (triage PRs and PRs with ungated findings), a PR detail view (findings cards, gate actions, post flow), a repos view (watch list, add and remove, backfill confirm), and a settings and status view (provider and auth detection, quota, paths, daemon health).
+3. The UI is a stateless view over the API, refreshed by SSE events. Closing the tab affects nothing.
+
+## Non-goals for v1
+
+Cut deliberately, most of them for the second time. Do not re-add without a spec:
+
+- The TUI, and any terminal diff rendering
+- Verification passes over posted findings (verdicts)
+- A second review agent, multi-agent orchestration, cross-agent dedup
+- Disk discovery of repos, ingest registries
+- The rules engine, rule import and export, repo-wide scan
+- Submitting reviews from LGTM
+- Plugin architecture, queue and approve workflow, dashboards, attention system
+- OAuth flows and multi-service auth
+- Cross-repo review, GitLab and other forges (the adapter boundary exists; implementations do not)
+- Webhook or relay based event delivery
+
+## v1.1 preview (contract only)
+
+A signed Swift MenuBarExtra shell, roughly 300 lines, polls `GET /api/status` and renders watcher health (greyed icon within 30 seconds of daemon death), the count of PRs awaiting gate or triage, the last cycle time, and menu actions to open the UI and stop the daemon through launchctl. v1 designs the read contract from day one; mutating tray actions such as pause ship with v1.1 endpoints of their own.

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -1,0 +1,95 @@
+# LGTM v1 tasks
+
+Status: draft for sign-off
+Date: 2026-08-29
+Order matters. Each milestone leaves the branch green (typecheck + tests) and ends with something runnable. Dogfooding starts at M4, not at the end.
+
+## M0: Clean slate
+
+- [ ] Upgrade Bun to current stable (>= 1.3.13 required; machine has 1.2.18)
+- [ ] Spike: run the Claude CLI's bundled review command in print mode against a full PR URL from a directory outside any checkout, on the pinned CLI version (>= 2.1.233), and confirm the findings survive the parser. The provider design depends on this result
+- [ ] Branch `v2` from `main`
+- [ ] First commit: remove everything except `LICENSE` and `.gitignore`. This includes all of `.kiro/`, the old packages, webapp, and Taskfile; new `.gitignore` entries keep the untracked clutter (built binaries, demo videos, `.bun-build` artifacts) out from then on
+- [ ] Second commit: `docs/spec/` (these three files), a stub `README.md` stating what is being built and pointing at the spec
+- [ ] Scaffold: `bun init --react=shadcn`, restructure into `src/` (core, forge, provider, store, daemon, api, ui), wire `build.ts` with `Bun.build()` + Tailwind plugin + compile, CI workflow: typecheck, test, build binary, `--version` smoke run
+
+Exit: `bun run build.ts` produces a styled hello-world binary serving the SPA shell on 127.0.0.1.
+
+## M1: Domain port
+
+- [ ] Port `okf.ts` (frontmatter + clone guard) and its 8 tests
+- [ ] Port `pr-ref.ts` and its 19 tests
+- [ ] Port `diff-parser.ts` with its 28 tests; add hunk slicing (given a file and line, return the surrounding hunk lines) with tests
+- [ ] Implement the new store layout (`src/store/reviews.ts`): meta.md and round files per design; adapt the 44 review-store tests; keep the `round:agent:id` finding-key rules and their regression tests
+- [ ] Implement `watch.md` and `config.md` read/write with defaults
+
+Exit: store round-trips reviews, findings, and config on disk; all ported tests green.
+
+## M2: Forge and provider
+
+- [ ] `ForgeAdapter` interface; GitHub implementation ported from `infra/github.ts` (13 tests) plus ETag support on `listOpenPRs` and `getReview` for pending-draft reconciliation
+- [ ] Draft-review module ported from `pending-review.ts` with submit removed; tests assert no `event` key, PENDING-or-throw, refuse-empty-comments, and that no exported function can publish
+- [ ] Token resolution chain (env, `gh auth token`, credentials file) with the silent-stderr test
+- [ ] Provider interface; claude implementation with the spawn/timeout/salvage `run()` pattern, prompt assembly (including do-not-repeat context), `extractFindings` + `validateFindings` ported with their tests
+- [ ] Login-shell PATH probe with cache, ENOENT re-probe, and manual override; unit tests with a fake shell
+- [ ] Fake `claude` shim for the offline harness (fixture findings, configurable failure modes)
+
+Exit: with the shim on PATH, a script can review a fixture PR end to end into the store, offline.
+
+## M3: Daemon
+
+- [ ] Scheduler: boot cycle, 15-minute jittered timer, in-flight overlap guard, wake catch-up
+- [ ] Poll cycle + classifier per design (auto-class, triage, draft hold and draft-to-ready transition, sticky skip, closed and reopen handling, failed-round retry with the 3-attempt cap, pending-review reconciliation via `getReview`); adapt the 18 `decidePR` tests to the triage model
+- [ ] Review queue with global concurrency 2, one entry per PR with latest-SHA-wins; failed rounds leave the PR retryable
+- [ ] Diff snapshot per reviewed SHA written into the PR dir at round completion (the hunk-slicing source)
+- [ ] Quota gate: `/usage` probe, parser, ok/throttled/fallback state machine, daily-cap counter, mode logging; tests with canned CLI outputs including unparseable ones
+- [ ] Backfill: on watch add, fetch open PRs with triage metadata, compute pre-selection
+- [ ] Event bus + notifier (terminal-notifier, osascript fallback, dedup rules, 4-hour reminder)
+- [ ] `daemon.json` rendezvous, pid lock with stale-pid recovery (rewrite the file and reset `queued`/`reviewing` metas at boot), port scan with health-probe handshake
+
+Exit: `lgtm up` against a real repo (or the shim) watches, classifies, reviews, and notifies; nothing touches GitHub write APIs.
+
+## M4: API and UI read path
+
+- [ ] HTTP API: health, status (the tray contract), events (SSE), prs, decision (review, skip, unskip, review-anyway), findings with sliced hunks; bearer auth, Host and Origin checks
+- [ ] CLI clients: `lgtm status` (non-zero when down), `lgtm open` (token fragment handoff), `lgtm watch add|rm|ls`
+- [ ] SPA: inbox and PR detail views read-only, SSE-driven refresh, empty states with watcher health
+- [ ] Repos view with add flow and backfill confirm pane (one decision call per selected PR)
+
+Exit: dogfooding begins. Watch this repo and one work repo; read real findings in the browser.
+
+## M5: The gate
+
+- [ ] Inbox decision buttons (skip, review, unskip, review-anyway) and the skipped section
+- [ ] Discard and restore on finding cards (PATCH by full finding key)
+- [ ] Validate endpoint and post flow: confirm pane with editable rendered body, held-back list, per-finding results, recreate path (flips posted findings back to open), dry run, zero-valid abort
+- [ ] `templates/review-body.md` shipped default
+- [ ] Settings view: detection results, path pins, quota thresholds, interval, daemon info
+
+Exit: full loop live: notification, gate in browser, PENDING draft on GitHub, submit in GitHub's UI.
+
+## M6: Lifecycle and release
+
+- [ ] `lgtm install` / `uninstall` (launchd plist, bootstrap, kickstart, bootout)
+- [ ] `fs.watch` on the store with SSE invalidation
+- [ ] Regression checklist from the old audit encoded as tests (see design, Testing)
+- [ ] README rewritten for what v1 actually is; TESTING.md for the offline harness
+- [ ] Release workflow: darwin-arm64 binary + checksum on GitHub Releases
+
+Exit: daemon survives reboot; a fresh machine could install from the release page.
+
+## Dogfood gate (before any v1.1 work)
+
+Two weeks of daily use, then review:
+
+- [ ] Did the quota gate ever block your interactive work, or fail to?
+- [ ] Were mentions missed (tier-b detection needed)?
+- [ ] Did skipped PRs need resurrection on new commits?
+- [ ] Is the pinned-tab notification gap painful enough to justify the tray now?
+- [ ] What died silently, and would the tray have caught it?
+
+## v1.1 (after the gate)
+
+- [ ] Swift MenuBarExtra shell against `/api/status` (design's tray contract)
+- [ ] codex CLI as a second provider entry
+- [ ] Whatever the dogfood review promoted

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -10,7 +10,7 @@ Order matters. Each milestone leaves the branch green (typecheck + tests) and en
 - [ ] Spike: run the Claude CLI's bundled review command in print mode against a full PR URL from a directory outside any checkout, on the pinned CLI version (>= 2.1.233), and confirm the findings survive the parser. The provider design depends on this result
 - [ ] Branch `v2` from `main`
 - [ ] First commit: remove everything except `LICENSE` and `.gitignore`. This includes all of `.kiro/`, the old packages, webapp, and Taskfile; new `.gitignore` entries keep the untracked clutter (built binaries, demo videos, `.bun-build` artifacts) out from then on
-- [ ] Second commit: `docs/spec/` (these three files), a stub `README.md` stating what is being built and pointing at the spec
+- [ ] Second commit: `docs/spec/`, `CONTEXT.md`, `docs/adr/`, and a stub `README.md` stating what is being built and pointing at the spec
 - [ ] Scaffold: `bun init --react=shadcn`, restructure into `src/` (core, forge, provider, store, daemon, api, ui), wire `build.ts` with `Bun.build()` + Tailwind plugin + compile, CI workflow: typecheck, test, build binary, `--version` smoke run
 
 Exit: `bun run build.ts` produces a styled hello-world binary serving the SPA shell on 127.0.0.1.


### PR DESCRIPTION
The plan for rebuilding LGTM from the ground up, decided in a requirements session and hardened by an adversarial review pass (48 findings fixed, 5 of them design blockers).

What it settles:

- **Delivery**: a Bun daemon plus a local web UI (React + shadcn, embedded in one compiled binary) replaces the TUI. A thin signed menu-bar shell follows in v1.1 against the same status API.
- **Loop**: watch, triage, review, post. Own/review-requested/mentioned PRs review automatically; everything else waits in a triage inbox. New commits trigger a fresh round with prior findings as do-not-repeat context. No verify passes in v1.
- **Agent**: claude CLI only, behind a pluggable provider interface. Quota-gated on real usage via `claude -p "/usage"` (pause above 70%, resume below 60%).
- **Posting**: PENDING draft reviews only. The codebase contains zero publish paths; submission happens in GitHub's UI.
- **Store**: markdown + frontmatter at `~/.lgtm-farm/`, new nested layout, no migration.
- **Process**: clean-slate `v2` branch (wipe first commit, `.kiro/` removed), battle-tested domain modules ported from `main` with their tests. Dogfooding starts at M4, and a two-week dogfood gate guards v1.1.

Merging this only adds `docs/spec/`; the rebuild itself starts on the `v2` branch afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)