### PR TITLE
Show what the agents are doing, and let you open the session

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A background daemon polls your watched repositories on a timer, 15 minutes by de
 
 1. **Classify.** A PR you authored, were requested to review, were assigned, or are @-mentioned in gets queued automatically. Everything else waits in a triage inbox until you tell it to review or skip.
 2. **Review.** Queued PRs go to the Claude CLI in print mode, one round per head commit. Findings, one per file and line, each with a severity, a comment, and an optional suggestion, land in a markdown file in the store.
-3. **Gate.** You open the local web UI, read each finding next to the diff hunk it's about, and discard whatever isn't worth raising.
+3. **Gate.** You open the local web UI's Reviews view, read each finding next to the diff hunk it's about, and discard whatever isn't worth raising.
 4. **Post.** What's left goes up as one pending draft review on GitHub. You open that draft in GitHub's own editor and submit it yourself, or don't.
 
-New commits on a PR LGTM already reviewed start a fresh round. The prompt tells the CLI what it already raised so it doesn't repeat itself, but there's no separate pass that re-checks old findings once they're posted (see [Status](#status)).
+New commits on a PR LGTM already reviewed start a fresh round. The prompt tells the CLI what it already raised so it doesn't repeat itself, but there's no separate pass that re-checks old findings once they're posted: see [status.md's Known gaps](docs/spec/status.md#known-gaps-by-design-or-by-an-open-seam).
 
 ## Why a draft review is the whole point
 
@@ -36,7 +36,7 @@ lgtm watch add owner/repo   # start watching a repository
 
 `lgtm open` finds the running daemon and launches your browser with a bearer token in the URL fragment; the page moves it to local storage and strips it from the address bar on load. Adding a repository, from the Repos view or with `watch add`, triggers a backfill: you see its currently open PRs with the auto-class ones pre-selected, and nothing auto-queues until you confirm the list. `lgtm status` reports daemon liveness, the last cycle, queue depth, and quota state, and exits non-zero when nothing is running.
 
-Read [Status](#status) before you try this. The daemon runs, but it has not yet been pointed at a real repository.
+GitHub auth has to resolve before a watched repo does anything: `GITHUB_TOKEN` or `GH_TOKEN`, then `gh auth token`, then a saved credential file (see [What it needs](#what-it-needs)). See [Status](#status) for what this build has actually been run against.
 
 ## The store
 
@@ -46,6 +46,7 @@ Everything LGTM knows lives at `~/.lgtm-farm/` as markdown files with YAML front
 ~/.lgtm-farm/
   token                        bearer token for the API, mode 0600
   daemon.json                  port, pid, start time
+  credentials.json             GitHub token, if you saved one this way rather than via gh; mode 0600
   config.md                    interval, quota thresholds, concurrency, binary path pins
   watch.md                     the repositories being polled
   agents/reviewer.md           the review prompt, yours to edit
@@ -54,7 +55,7 @@ Everything LGTM knows lives at `~/.lgtm-farm/` as markdown files with YAML front
     meta.md                    state, classification, head SHA, round count
     r<N>-<agent>.md            one file per review round, findings in frontmatter
     diff-<sha>.patch           a snapshot of the diff at each reviewed head
-  logs/daemon.log
+  logs/daemon.log              only if you ran `lgtm install`; it's launchd's stdout/stderr redirect
 ```
 
 `agents/reviewer.md` is the file worth opening first. It's the block of instructions the daemon appends to the CLI's built-in review command, written in your own words, not shipped as a fixed prompt.
@@ -67,16 +68,18 @@ v1 targets macOS only (`lgtm install` writes a launchd LaunchAgent). [ADR 0002](
 
 ## Status
 
-This is a ground-up rebuild on the `v2` branch. The typecheck is clean, the test suite passes, the binary builds, and the daemon runs: it creates its store, binds loopback, serves the UI and the API, polls on a schedule, and shuts down cleanly. What it has never done is watch a real repository or post a real draft review. Every run so far has been against an empty store with no GitHub token, so the first review round and the first post are still ahead. Read [docs/spec/status.md](docs/spec/status.md) for the specifics, milestone by milestone.
+This is a ground-up rebuild, merged to `main`. The typecheck is clean, the test suite passes, and the binary builds. The daemon runs end to end: it creates its store, binds loopback, serves the UI and the API, polls on a schedule, and shuts down cleanly. It has authenticated against real GitHub, listed real pull requests, and reviewed real PRs end to end.
+
+It's one person's tool. Nobody but its author has run it, and the two weeks of daily use that gate v1.1 haven't happened yet. This isn't finished; read [docs/spec/status.md](docs/spec/status.md) for the milestone-by-milestone record, including what's still unproven.
 
 ## Learn more
 
 - [docs/spec/requirements.md](docs/spec/requirements.md), what v1 does and what it deliberately doesn't
 - [docs/spec/design.md](docs/spec/design.md), how it's built
 - [docs/architecture.md](docs/architecture.md), where data lives and the lines it cannot cross
-- [docs/spec/tasks.md](docs/spec/tasks.md), the milestone plan (its checkboxes lag reality; [status.md](docs/spec/status.md) is the current record)
+- [docs/spec/tasks.md](docs/spec/tasks.md), the milestone plan the build followed, kept as a record now that every milestone has landed
 - [docs/spec/decisions.md](docs/spec/decisions.md), why, in the words of the session that decided it
 - [docs/spec/models.md](docs/spec/models.md), which model tier each kind of task needs, and what the build showed about that
 - [docs/adr/](docs/adr/), the five decisions that were hard to reverse
 - [CONTEXT.md](CONTEXT.md), the project glossary
-- [TESTING.md](TESTING.md), running the suite and driving the review loop offline
+- [TESTING.md](TESTING.md), running the suite, including the offline end-to-end journeys, and driving the review loop by hand

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,9 +40,35 @@ process.env.FAKE_CLAUDE_MODE = "prose";
 const outcome = await run({ ...input, binPath: SHIM });
 ```
 
-`src/provider/claude.test.ts` and `src/provider/index.test.ts` run the real subprocess round trip against every mode. `src/daemon/quota.test.ts` spawns the shim in `usage` mode for the quota parser. The daemon-level cycle and boot tests inject a fake `review` function instead of spawning a process, so they don't touch the shim directly, but they do run the rest of the loop, classify, queue, gate, dry-run post, against fixture data with no I/O at all.
+`src/provider/claude.test.ts` and `src/provider/index.test.ts` run the real subprocess round trip against every mode. `src/daemon/quota.test.ts` spawns the shim in `usage` mode for the quota parser. `src/daemon/cycle.test.ts` and the boot tests inject a fake `review` function instead of spawning a process, so they exercise the rest of the loop, classify, queue, gate, dry-run post, against fixture data with no I/O at all. `test/e2e/` is the one place that spawns the shim through a whole booted daemon rather than injecting a fake anywhere in the chain; see [Driving the review loop through a real daemon](#driving-the-review-loop-through-a-real-daemon) below.
 
 To point a script or a manual run at the shim instead of the real CLI, set `claude_path` in `config.md` to the shim's absolute path (a manual pin skips the binary resolver's own PATH probe) and set `FAKE_CLAUDE_MODE` before starting whatever you're running. `test/fixtures/README.md` has the full flag and mode reference.
+
+## Driving the review loop through a real daemon
+
+Everything above tests one module, or the loop with a fake standing in
+somewhere in the chain. `test/e2e/` is different: it boots a real daemon,
+`createDaemon` assembling the same modules `lgtm up` does, in the same order,
+against a fake GitHub on a real loopback socket and the fake `claude` shim on
+PATH. No real network, no real GitHub, no real `claude`; `globalThis.fetch` is
+replaced with one that rewrites `https://api.github.com` onto the fake's port
+and throws on any other host, so a new code path that reaches for the real
+internet fails the suite instead of passing quietly.
+
+```bash
+bun test test/e2e/loop.test.ts     # the journeys alone, about a second
+```
+
+Nine journeys, seventeen tests: watching a repo backfills triage without
+reviewing anything, an auto-class PR gets reviewed and its findings land in
+the API, a triage PR waits and a Skip survives a new commit, the gate posts
+one finding and holds two whose lines left the diff, posting twice is
+refused and recreate replaces the old draft, a draft submitted in GitHub's UI
+stops blocking the next post, a garbage round fails without marking the PR
+reviewed, the auth choke point refuses a missing or wrong bearer and a
+foreign Origin, and the quota gate parks a PR above the pause threshold with
+no round run. `test/e2e/README.md` has the full account, including which
+mutations these tests catch that the module tests don't.
 
 ## Things worth breaking
 

--- a/docs/spec/design.md
+++ b/docs/spec/design.md
@@ -44,7 +44,7 @@ Single-writer rule: only the daemon writes the store. The SPA and the CLI mutate
                                   #   binary pins (claude_path, gh_path); a pin skips the probe
   watch.md                        # frontmatter list: {owner, repo, addedAt, lastPolledAt, etag}
   agents/
-    reviewer.md                   # frontmatter: provider, timeout_minutes, severity_floor, enabled
+    reviewer.md                   # frontmatter: provider, model, timeout_minutes, severity_floor, enabled
                                   # body: the review prompt, appended to the CLI's built-in /review
   templates/
     review-body.md                # post body template with placeholders
@@ -56,7 +56,9 @@ Single-writer rule: only the daemon writes the store. The SPA and the CLI mutate
     r<N>-<agent>.md               # one file per round per agent, frontmatter below
     r<N>-<agent>.raw.txt          # only when parsing failed
   logs/
-    daemon.log                    # rotating, plain text
+    daemon.log                    # plain text; only exists if `lgtm install` created it,
+                                  #   as launchd's stdout/stderr redirect. `lgtm up` in
+                                  #   the foreground doesn't write it
 ```
 
 `meta.md` frontmatter:
@@ -79,6 +81,12 @@ pendingReviewId: 987654  # set while a draft exists on GitHub; cleared when getR
                          #   reports it is no longer pending
 closedAt: null
 updatedAt: 2026-08-29T10:00:00Z
+createdAt: 2026-08-20T09:00:00Z   # triage metadata (R2.5), all six nullable: fetched only
+additions: 214                    #   for PRs entering triage or backfill, and GitHub
+deletions: 38                     #   computes mergeable asynchronously, so a null here
+changedFiles: 6                   #   renders as "computing" or a dash, never as zero
+mergeable: true
+checkStatus: success               # success | failure | pending | none, from the Checks API
 ```
 
 `r<N>-<agent>.md` frontmatter holds the canonical findings array; the markdown body is a generated human-readable rendering of the same data:
@@ -126,7 +134,7 @@ At boot, and whenever `daemon.json` names a dead pid, the daemon rewrites `daemo
 
 Classification reads the PR list item: `user.login` (own), `requested_reviewers` (requested), `assignees` (assigned), `@login` in title or body (mentioned). The authenticated login comes from `GET /user`, fetched once and cached.
 
-Triage metadata (additions, deletions, changed files, mergeable state) needs the per-PR detail endpoint, so the daemon fetches it only for PRs entering triage or the backfill list, not on every cycle. CI status is one `GET /commits/{sha}/check-runs` per triage PR; this reads the Checks API only, so CI reporting through the legacy commit Status API renders as "no checks" in v1. GitHub computes `mergeable` asynchronously; a null value renders as "computing", not as a failure.
+Triage metadata (additions, deletions, changed files, mergeable state) needs the per-PR detail endpoint. `refreshTriageMetadata` fetches it for PRs entering triage or the backfill list, and also refreshes it whenever a known PR's head SHA changes, or when the stored check status is still `pending`, so a PR sitting in triage doesn't keep showing a stale size or a check run that has since resolved. CI status is one `GET /commits/{sha}/check-runs` per refresh; this reads the Checks API only, so CI reporting through the legacy commit Status API renders as "no checks" in v1. GitHub computes `mergeable` asynchronously; a null value renders as "computing", not as a failure.
 
 Scheduler: one cycle at daemon start, then a 15-minute timer with small jitter. Timers do not fire during sleep, so the daemon subscribes to wake notifications and runs a catch-up cycle on wake. An in-flight guard prevents overlapping cycles (a real bug in the old watcher).
 
@@ -219,7 +227,7 @@ Bun.serve, bound explicitly to 127.0.0.1, default port 4747, scan to 4757 on con
 | `/api/health` | GET | `{app:"lgtm", version, pid}`, unauthenticated |
 | `/api/status` | GET | The tray contract: daemon uptime, last cycle time and outcome per repo, queue length, quota state and mode, provider and token detection, counts awaiting gate and triage |
 | `/api/events` | GET | SSE stream; accepts `?token=` since EventSource cannot set headers |
-| `/api/prs` | GET | PR list with state, classification, triage metadata; filters by state |
+| `/api/prs` | GET | PR list with state, classification, triage metadata; filters by `state` (one or more), `closed` (`exclude`\|`include`\|`only`), `watched` (`only`\|`all`), and `withFindings` |
 | `/api/prs/:owner/:repo/:number/decision` | POST | `{action: "review" \| "skip" \| "unskip" \| "review-anyway"}` |
 | `/api/prs/:owner/:repo/:number/findings` | GET | Rounds and findings, hunks sliced from the stored `diff-<sha>.patch` of each finding's round, GitHub link as fallback when the snapshot is missing |
 | `/api/prs/:owner/:repo/:number/findings/:key` | PATCH | `{state: "discarded" \| "open"}`, key in the canonical `r2:reviewer:f1` form |
@@ -238,12 +246,12 @@ Stack: React 19, shadcn/ui (new-york), Tailwind v4. Scaffolded from `bun init --
 
 Views:
 
-- **Inbox**: triage PRs (skip / review buttons, metadata line), PRs with ungated findings (finding count by severity, jump to detail), and a collapsed skipped section with unskip buttons. The empty state doubles as a health check showing watcher liveness and next poll time.
+- **Reviews**: every PR the store knows about, filtered by two independent controls rather than the single Inbox this section used to describe. A status filter bar maps onto the daemon's `state` query param, except for "ready to gate", which asks for `withFindings` instead, since a PR can carry ungated findings from an earlier round while a fresh round is in flight. A separate completed toggle filters on `closedAt`, not on `state`, because a PR that closes while skipped keeps `state: "skipped"`. The reason for splitting Inbox into Reviews: the old Inbox dropped a PR the moment it had nothing left to gate, so a reviewed PR with zero findings and a PR that was never reviewed both rendered as nothing (`src/ui/views/Reviews.tsx`'s docstring has the full account).
 - **PR detail**: header (title, author, classification badge, head SHA, GitHub link), finding cards grouped by file. Card: severity chip, `file:line`, comment, suggestion block, sliced diff hunk (about 10 lines, server-rendered from the ported diff parser), discard button, GitHub deep link. Footer: "Post draft (n findings)" opening the confirm pane (editable body, held-back list), then per-finding results and "Open pending review on GitHub".
 - **Repos**: watch list with last-poll time, add field (`owner/repo`), remove. Adding opens the backfill pane: open PRs with metadata, auto-class rows pre-checked, one confirm.
 - **Settings**: provider and gh detection with resolved paths and manual pins, token status, quota thresholds, interval, daemon info.
 
-Keyboard: `j`/`k` between cards, `d` discard, `enter` confirm. Nothing else in v1.
+Keyboard: `j`/`k` between cards, `d` discard, `enter` confirm, as designed. Not yet built: no view binds a keydown listener, so none of these fire today.
 
 ## Notifications
 
@@ -261,7 +269,7 @@ Transport probe order: `terminal-notifier` (resolved like other binaries; suppor
 
 ## Build and distribution
 
-- Bun >= 1.3.13 required. The CSS `@layer` bug that mangles Tailwind v4 output was a 1.3.0 regression fixed in 1.3.13 (April 2026), so a plain 1.3.x floor would admit exactly the broken versions; this machine's 1.2.18 must be upgraded.
+- Bun >= 1.3.13 required. The CSS `@layer` bug that mangles Tailwind v4 output was a 1.3.0 regression fixed in 1.3.13 (April 2026), so a plain 1.3.x floor would admit exactly the broken versions. The dev machine runs 1.4.0; CI pins 1.4.0 too (`.github/workflows/ci.yml`, `release.yml`).
 - Dev loop: `bun --hot src/main.ts`, Bun.serve with `routes` and the HTML import; Tailwind via `bun-plugin-tailwind` configured in `bunfig.toml` `[serve.static]`.
 - Production: `bun run build.ts`, which calls the `Bun.build()` JS API with `compile: { outfile: "dist/lgtm" }` and the Tailwind plugin. Never the `bun build --compile` CLI. It ignores bundler plugins and produces an unstyled binary (open Bun bug).
 - Distribution v1: a GitHub release with the darwin-arm64 binary and a checksum. Plain binaries downloaded via curl carry no Gatekeeper burden. No brew tap, no signing, until after the dogfood period.
@@ -287,6 +295,7 @@ Everything else in the old tree is reference material, not a porting target.
 - The no-publish invariant keeps its explicit tests: request builder emits no `event` key; the GitHub adapter exposes no submitting function.
 - The offline harness from the old TESTING.md ports over. A fake `claude` shim on PATH lets the full watch, review, gate, and dry-run-post loop run without network or quota.
 - The old removals audit and the final pre-submission review together yield a seven-item regression checklist; each item gets a test in the module it belongs to: a watch add through the API lands in `watch.md` and is polled on the next cycle, the interval default matches its documentation, missing binaries print nothing to stderr during detection, PR listing respects pagination, dry-run writes nothing, cache keys are repo-qualified, an all-failed round does not mark the PR reviewed.
+- `test/e2e/` closes the gap module tests can't see: the joins between modules, not the modules themselves. It boots a real daemon against a fake GitHub on a real loopback socket and the fake Claude shim, and drives nine journeys (watching, auto-class, triage, the gate, double-posting, submitted-draft reconciliation, a garbage-output round, the auth choke point, and the quota gate) through the store, the API, and the fake's own request log. See [test/e2e/README.md](../../test/e2e/README.md).
 
 ## Deferred decisions
 

--- a/docs/spec/status.md
+++ b/docs/spec/status.md
@@ -1,12 +1,24 @@
 # LGTM v1 build status
 
-Companion to [design.md](design.md), [requirements.md](requirements.md), and [tasks.md](tasks.md). Written from what the code and its tests actually do, not from tasks.md's checkboxes, which are still all unchecked even though most of the milestones below have landed. Treat this document, not that one, as the record of what's actually built.
+Companion to [design.md](design.md) and [requirements.md](requirements.md).
+[tasks.md](tasks.md) is the milestone plan the build followed; it's marked
+complete now, and this document is the one to read for what the result
+actually does.
 
-This branch has more than one agent working on it at once. The specifics below are a snapshot, not a promise about tomorrow's commit.
+This branch has more than one agent working on it at once. The specifics
+below are a snapshot, not a promise about tomorrow's commit.
 
 ## Where things stand
 
-As of this writing, `bun test` reports 991 passing tests across 36 files, 2459 assertions, in under 10 seconds. `bunx tsc --noEmit` is clean under `strict` plus `noUncheckedIndexedAccess`. `bun run build.ts` produces a `dist/lgtm` binary that runs and answers `--version`. Run the suite yourself for the current numbers; they move every time a task lands.
+As of this writing, `bun test` reports 1126 passing tests across 40 files,
+3129 assertions, in under 10 seconds. `bunx tsc --noEmit` is clean under
+`strict` plus `noUncheckedIndexedAccess`. `bun run build.ts` produces a
+`dist/lgtm` binary that runs and answers `--version`. Run the suite yourself
+for the current numbers; they move every time a task lands.
+
+The daemon has run against real GitHub: it authenticated, listed real open
+pull requests, and reviewed real PRs end to end, writing real findings to the
+store. It is one person's tool, run so far by nobody but its author.
 
 ## Done
 
@@ -14,32 +26,26 @@ As of this writing, `bun test` reports 991 passing tests across 36 files, 2459 a
 - **M1, domain port.** `okf.ts`'s frontmatter round trip and its `structuredClone` guard, `pr-ref.ts`, the diff parser plus hunk slicing for finding cards, the new store layout (`meta.md`, per-round files, the `r<N>:<agent>:<id>` finding key), and `watch.md` / `config.md` read and write with their documented defaults.
 - **M2, forge and provider.** The GitHub `ForgeAdapter` with ETag support on the list and review-reconciliation calls, the draft-review module (no `event` key, throws unless the response is `PENDING`, refuses an empty comment list, and exposes no function that could publish), the GitHub token resolution chain, the Claude provider's spawn/timeout/salvage loop and prompt assembly, the login-shell PATH probe with its manual-pin override, and the fake `claude` shim at `test/fixtures/fake-claude.ts` (see [TESTING.md](../../TESTING.md)).
 - **M3, daemon, as modules.** The scheduler, poll cycle and classifier, review queue, quota gate, backfill, diff snapshotting, and notifier are each built and tested standalone. `createDaemon` (`src/daemon/boot.ts`) assembles all of them into one running daemon and has its own boot-sequence tests covering the lock, the binary probe order, and the rendezvous file. `lgtm up` runs it, and a booted daemon creates its store, binds loopback, serves the UI and the API, polls on its schedule, and shuts down cleanly on a signal.
-- **M4, API read path.** Every read route in design.md's HTTP API table (`health`, `status`, `events`, `prs`, `prs/.../findings`, `watchlist`, `config`) is defined and mounted in the live route table (`src/api/routes.ts`), with a test matrix that walks the table and asserts bearer, Host, and Origin checks on every entry. The two mutating routes this milestone also needs, `decision` and the findings `PATCH`, are mounted and tested too. `lgtm status`, `lgtm open`, and `lgtm watch add|rm|ls` are real implementations against that API, not stubs.
-- **M6, partially.** `lgtm install` and `lgtm uninstall` write and bootstrap a real launchd plist and have their own tests (`src/cli/install.ts`, `src/cli/install.test.ts`). The release workflow (`.github/workflows/release.yml`) builds the darwin-arm64 binary and a checksum on a version tag. The seven-item regression checklist from design.md's testing section is encoded as tests, one `describe` block per item, in `src/regression.test.ts` (see [TESTING.md](../../TESTING.md)).
+- **M4, API read path.** Every read route in design.md's HTTP API table (`health`, `status`, `events`, `prs`, `prs/.../findings`, `watchlist`, `config`) is defined and mounted in the live route table (`src/api/routes.ts`), with a test matrix that walks the table and asserts bearer, Host, and Origin checks on every entry. `lgtm status`, `lgtm open`, and `lgtm watch add|rm|ls` are real implementations against that API, not stubs.
+- **M5, the gate.** `src/api/post.ts` and `src/ui/views/PostPane.tsx` carry the full post flow: the validate endpoint, discard and restore by full finding key (`r2:reviewer:f1`, never a bare id), the confirm pane with an editable body rendered from `templates/review-body.md` (`src/store/templates.ts`), the recreate path, the zero-valid abort, and dry run. The Settings view is real and reads the same detection results the daemon logs. The loop this milestone promised, notification through a `PENDING` draft on GitHub, is wired end to end; see [What remains unproven](#what-remains-unproven) for what wiring alone can't settle.
+- **M6, lifecycle and release.** `lgtm install` and `lgtm uninstall` write and bootstrap a real launchd plist and have their own tests (`src/cli/install.ts`, `src/cli/install.test.ts`). The store watcher (`src/daemon/store-watch.ts`) runs `fs.watch` on `~/.lgtm-farm` and pushes SSE invalidation, so a hand-edited file shows up in the UI without a restart. The release workflow (`.github/workflows/release.yml`) builds the darwin-arm64 binary and a checksum on a version tag. The seven-item regression checklist from design.md's testing section is encoded as tests, one `describe` block per item, in `src/regression.test.ts` (see [TESTING.md](../../TESTING.md)).
+- **End-to-end journeys**, beyond any single milestone. `test/e2e/` boots a real daemon (`createDaemon`, the same assembly `lgtm up` runs) against a fake GitHub on a real loopback socket and the fake Claude shim, and drives nine journeys, seventeen tests, through watching, classifying, reviewing, gating, and posting. It's mutation-checked: six of the seventeen mutations first run against these tests survived, because the journey they broke only walked the cooperating path. See [test/e2e/README.md](../../test/e2e/README.md).
 
-## Not wired yet
+## What's wired
 
 The seams that parallel work leaves behind are closed. `lgtm up` starts the
 daemon, the real API router and the SPA are mounted on the port it binds,
-`App.tsx` renders the four views, `postRoutes()` is spliced into the route
-table, the post pane is mounted in the PR detail view, and the store watcher
-runs with the daemon.
+`App.tsx` renders the Reviews, PR detail, Repos, and Settings views,
+`postRoutes()` is spliced into the route table, the post pane is mounted in
+the PR detail view, and the store watcher runs with the daemon.
 
-What remains unproven is the part no amount of wiring settles.
+## What remains unproven
 
-- **No review has ever run against a real pull request.** The daemon has been
-  booted against a live GitHub token and a real repository: it authenticated,
-  listed open pull requests, and wrote the watch list. That repository had no
-  open PRs, so nothing has yet been classified, queued, reviewed, or posted.
-  The first real round, and the first draft review, are still ahead.
-- **The keyboard shortcuts in design.md's Web UI section are not bound.**
-  `j`/`k` between cards, `d` to discard, `enter` to confirm. They need a
-  document-level listener that no view owns, and the render harness has no DOM
-  to exercise it with.
-- **`src/ui/api.ts` still carries its own `validate` and `post` methods**,
-  written before `src/api/post.ts` existed and parsing shapes it does not
-  send. `src/ui/actions.ts` is the client the gate actually uses. The stale
-  pair should go, so the gate has one client rather than two.
+Wiring settles whether the pieces are connected. It doesn't settle these.
+
+- **Whether a draft review has landed on a real GitHub pull request, and been submitted there by a human, is unconfirmed.** The daemon has reviewed real PRs end to end and written real findings to the store. The post flow itself is built and is exercised end to end against a fake GitHub in `test/e2e/`. Nobody has yet watched a `PENDING` review appear on a real PR and submitted it in GitHub's own UI. That's still ahead.
+- **The keyboard shortcuts in design.md's Web UI section are not bound.** `j`/`k` between cards, `d` to discard, `enter` to confirm. They need a document-level listener that no view owns, and the render harness has no DOM to exercise it with.
+- **`src/ui/api.ts` still carries its own `validate` and `post` methods** (`src/ui/api.ts:582-583`), written before `src/api/post.ts` existed and parsing shapes it does not send. `src/ui/actions.ts` is the client the gate actually uses. The stale pair should go, so the gate has one client rather than two.
 
 ## Known gaps, by design or by an open seam
 
@@ -49,7 +55,3 @@ These are not bugs waiting for a fix. Each is a deliberate trade-off or a limit 
 - **A mid-review head move loses that round's diff snapshot.** `ForgeAdapter.getDiff` only returns a PR's *current* head diff; there's no way to ask GitHub for the diff at an arbitrary earlier SHA. A review takes minutes (the M0 spike measured 5m44s for a two-file PR), so `src/daemon/snapshot.ts` checks the live head immediately before and immediately after fetching, and writes nothing if it moved either time. The finding card falls back to a GitHub link when that happens; it's a known, handled state, not a crash, but an active PR can lose its inline diff hunks on the card mid-review.
 - **`watch.md` takes two read-modify-write passes per repo per cycle.** `recordPoll` in `src/daemon/cycle.ts` calls `updateLastPolledAt`, then, only if the ETag changed, `updateETag`; each is its own full load and save of the file (`src/store/watch-list.ts`). Harmless at the size of a personal watch list, but it's two write windows instead of one, and a crash between them would leave a stale ETag next to a fresh poll timestamp.
 - **The close pass reads one file per known-closed PR, every cycle, forever.** `closeMissingPR` in `src/daemon/cycle.ts` calls `loadMeta` for every locally-known PR no longer in the repo's open list, checks `closedAt`, and returns once it finds the PR already marked closed. There's no memory of "already handled this one", so a repo's entire history of merged PRs gets re-read on every poll indefinitely. Fine at personal scale; a real cost if the store ever holds thousands of closed PRs for one repo.
-
-## Reading this alongside tasks.md
-
-tasks.md's checkboxes are all unchecked. That's the file falling behind the work, not a sign the work didn't happen; this document is the one to trust.

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -1,80 +1,84 @@
 # LGTM v1 tasks
 
-Status: draft for sign-off
+Status: complete. M0 through M6 have landed; the boxes below are checked
+against the code, not against memory. Kept as the record of the order the
+build happened in. [status.md](status.md) is the current record of what the
+result does; read that one if you want to know what LGTM can do today rather
+than how it got built.
 Date: 2026-08-29
 Order matters. Each milestone leaves the branch green (typecheck + tests) and ends with something runnable. Dogfooding starts at M4, not at the end.
 
 ## M0: Clean slate
 
-- [ ] Upgrade Bun to current stable (>= 1.3.13 required; machine has 1.2.18)
-- [ ] Spike: run the Claude CLI's bundled review command in print mode against a full PR URL from a directory outside any checkout, on the pinned CLI version (>= 2.1.233), and confirm the findings survive the parser. The provider design depends on this result
-- [ ] Branch `v2` from `main`
-- [ ] First commit: remove everything except `LICENSE` and `.gitignore`. This includes all of `.kiro/`, the old packages, webapp, and Taskfile; new `.gitignore` entries keep the untracked clutter (built binaries, demo videos, `.bun-build` artifacts) out from then on
-- [ ] Second commit: `docs/spec/`, `CONTEXT.md`, `docs/adr/`, and a stub `README.md` stating what is being built and pointing at the spec
-- [ ] Scaffold: `bun init --react=shadcn`, restructure into `src/` (core, forge, provider, store, daemon, api, ui), wire `build.ts` with `Bun.build()` + Tailwind plugin + compile, CI workflow: typecheck, test, build binary, `--version` smoke run
+- [x] Upgrade Bun to current stable (>= 1.3.13 required; machine has 1.2.18)
+- [x] Spike: run the Claude CLI's bundled review command in print mode against a full PR URL from a directory outside any checkout, on the pinned CLI version (>= 2.1.233), and confirm the findings survive the parser. The provider design depends on this result
+- [x] Branch `v2` from `main`
+- [x] First commit: remove everything except `LICENSE` and `.gitignore`. This includes all of `.kiro/`, the old packages, webapp, and Taskfile; new `.gitignore` entries keep the untracked clutter (built binaries, demo videos, `.bun-build` artifacts) out from then on
+- [x] Second commit: `docs/spec/`, `CONTEXT.md`, `docs/adr/`, and a stub `README.md` stating what is being built and pointing at the spec
+- [x] Scaffold: `bun init --react=shadcn`, restructure into `src/` (core, forge, provider, store, daemon, api, ui), wire `build.ts` with `Bun.build()` + Tailwind plugin + compile, CI workflow: typecheck, test, build binary, `--version` smoke run
 
 Exit: `bun run build.ts` produces a styled hello-world binary serving the SPA shell on 127.0.0.1.
 
 ## M1: Domain port
 
-- [ ] Port `okf.ts` (frontmatter + clone guard) and its 8 tests
-- [ ] Port `pr-ref.ts` and its 19 tests
-- [ ] Port `diff-parser.ts` with its 28 tests; add hunk slicing (given a file and line, return the surrounding hunk lines) with tests
-- [ ] Implement the new store layout (`src/store/reviews.ts`): meta.md and round files per design; adapt the 44 review-store tests; keep the `round:agent:id` finding-key rules and their regression tests
-- [ ] Implement `watch.md` and `config.md` read/write with defaults
+- [x] Port `okf.ts` (frontmatter + clone guard) and its 8 tests
+- [x] Port `pr-ref.ts` and its 19 tests
+- [x] Port `diff-parser.ts` with its 28 tests; add hunk slicing (given a file and line, return the surrounding hunk lines) with tests
+- [x] Implement the new store layout (`src/store/reviews.ts`): meta.md and round files per design; adapt the 44 review-store tests; keep the `round:agent:id` finding-key rules and their regression tests
+- [x] Implement `watch.md` and `config.md` read/write with defaults
 
 Exit: store round-trips reviews, findings, and config on disk; all ported tests green.
 
 ## M2: Forge and provider
 
-- [ ] `ForgeAdapter` interface; GitHub implementation ported from `infra/github.ts` (13 tests) plus ETag support on `listOpenPRs` and `getReview` for pending-draft reconciliation
-- [ ] Draft-review module ported from `pending-review.ts` with submit removed; tests assert no `event` key, PENDING-or-throw, refuse-empty-comments, and that no exported function can publish
-- [ ] Token resolution chain (env, `gh auth token`, credentials file) with the silent-stderr test
-- [ ] Provider interface; claude implementation with the spawn/timeout/salvage `run()` pattern, prompt assembly (including do-not-repeat context), `extractFindings` + `validateFindings` ported with their tests
-- [ ] Login-shell PATH probe with cache, ENOENT re-probe, and manual override; unit tests with a fake shell
-- [ ] Fake `claude` shim for the offline harness (fixture findings, configurable failure modes)
+- [x] `ForgeAdapter` interface; GitHub implementation ported from `infra/github.ts` (13 tests) plus ETag support on `listOpenPRs` and `getReview` for pending-draft reconciliation
+- [x] Draft-review module ported from `pending-review.ts` with submit removed; tests assert no `event` key, PENDING-or-throw, refuse-empty-comments, and that no exported function can publish
+- [x] Token resolution chain (env, `gh auth token`, credentials file) with the silent-stderr test
+- [x] Provider interface; claude implementation with the spawn/timeout/salvage `run()` pattern, prompt assembly (including do-not-repeat context), `extractFindings` + `validateFindings` ported with their tests
+- [x] Login-shell PATH probe with cache, ENOENT re-probe, and manual override; unit tests with a fake shell
+- [x] Fake `claude` shim for the offline harness (fixture findings, configurable failure modes)
 
 Exit: with the shim on PATH, a script can review a fixture PR end to end into the store, offline.
 
 ## M3: Daemon
 
-- [ ] Scheduler: boot cycle, 15-minute jittered timer, in-flight overlap guard, wake catch-up
-- [ ] Poll cycle + classifier per design (auto-class, triage, draft hold and draft-to-ready transition, sticky skip, closed and reopen handling, failed-round retry with the 3-attempt cap, pending-review reconciliation via `getReview`); adapt the 18 `decidePR` tests to the triage model
-- [ ] Review queue with global concurrency 2, one entry per PR with latest-SHA-wins; failed rounds leave the PR retryable
-- [ ] Diff snapshot per reviewed SHA written into the PR dir at round completion (the hunk-slicing source)
-- [ ] Quota gate: `/usage` probe, parser, ok/throttled/fallback state machine, daily-cap counter, mode logging; tests with canned CLI outputs including unparseable ones
-- [ ] Backfill: on watch add, fetch open PRs with triage metadata, compute pre-selection
-- [ ] Event bus + notifier (terminal-notifier, osascript fallback, dedup rules, 4-hour reminder)
-- [ ] `daemon.json` rendezvous, pid lock with stale-pid recovery (rewrite the file and reset `queued`/`reviewing` metas at boot), port scan with health-probe handshake
+- [x] Scheduler: boot cycle, 15-minute jittered timer, in-flight overlap guard, wake catch-up
+- [x] Poll cycle + classifier per design (auto-class, triage, draft hold and draft-to-ready transition, sticky skip, closed and reopen handling, failed-round retry with the 3-attempt cap, pending-review reconciliation via `getReview`); adapt the 18 `decidePR` tests to the triage model
+- [x] Review queue with global concurrency 2, one entry per PR with latest-SHA-wins; failed rounds leave the PR retryable
+- [x] Diff snapshot per reviewed SHA written into the PR dir at round completion (the hunk-slicing source)
+- [x] Quota gate: `/usage` probe, parser, ok/throttled/fallback state machine, daily-cap counter, mode logging; tests with canned CLI outputs including unparseable ones
+- [x] Backfill: on watch add, fetch open PRs with triage metadata, compute pre-selection
+- [x] Event bus + notifier (terminal-notifier, osascript fallback, dedup rules, 4-hour reminder)
+- [x] `daemon.json` rendezvous, pid lock with stale-pid recovery (rewrite the file and reset `queued`/`reviewing` metas at boot), port scan with health-probe handshake
 
 Exit: `lgtm up` against a real repo (or the shim) watches, classifies, reviews, and notifies; nothing touches GitHub write APIs.
 
 ## M4: API and UI read path
 
-- [ ] HTTP API: health, status (the tray contract), events (SSE), prs, decision (review, skip, unskip, review-anyway), findings with sliced hunks; bearer auth, Host and Origin checks
-- [ ] CLI clients: `lgtm status` (non-zero when down), `lgtm open` (token fragment handoff), `lgtm watch add|rm|ls`
-- [ ] SPA: inbox and PR detail views read-only, SSE-driven refresh, empty states with watcher health
-- [ ] Repos view with add flow and backfill confirm pane (one decision call per selected PR)
+- [x] HTTP API: health, status (the tray contract), events (SSE), prs, decision (review, skip, unskip, review-anyway), findings with sliced hunks; bearer auth, Host and Origin checks
+- [x] CLI clients: `lgtm status` (non-zero when down), `lgtm open` (token fragment handoff), `lgtm watch add|rm|ls`
+- [x] SPA: inbox and PR detail views read-only, SSE-driven refresh, empty states with watcher health
+- [x] Repos view with add flow and backfill confirm pane (one decision call per selected PR)
 
 Exit: dogfooding begins. Watch this repo and one work repo; read real findings in the browser.
 
 ## M5: The gate
 
-- [ ] Inbox decision buttons (skip, review, unskip, review-anyway) and the skipped section
-- [ ] Discard and restore on finding cards (PATCH by full finding key)
-- [ ] Validate endpoint and post flow: confirm pane with editable rendered body, held-back list, per-finding results, recreate path (flips posted findings back to open), dry run, zero-valid abort
-- [ ] `templates/review-body.md` shipped default
-- [ ] Settings view: detection results, path pins, quota thresholds, interval, daemon info
+- [x] Inbox decision buttons (skip, review, unskip, review-anyway) and the skipped section
+- [x] Discard and restore on finding cards (PATCH by full finding key)
+- [x] Validate endpoint and post flow: confirm pane with editable rendered body, held-back list, per-finding results, recreate path (flips posted findings back to open), dry run, zero-valid abort
+- [x] `templates/review-body.md` shipped default
+- [x] Settings view: detection results, path pins, quota thresholds, interval, daemon info
 
 Exit: full loop live: notification, gate in browser, PENDING draft on GitHub, submit in GitHub's UI.
 
 ## M6: Lifecycle and release
 
-- [ ] `lgtm install` / `uninstall` (launchd plist, bootstrap, kickstart, bootout)
-- [ ] `fs.watch` on the store with SSE invalidation
-- [ ] Regression checklist from the old audit encoded as tests (see design, Testing)
-- [ ] README rewritten for what v1 actually is; TESTING.md for the offline harness
-- [ ] Release workflow: darwin-arm64 binary + checksum on GitHub Releases
+- [x] `lgtm install` / `uninstall` (launchd plist, bootstrap, kickstart, bootout)
+- [x] `fs.watch` on the store with SSE invalidation
+- [x] Regression checklist from the old audit encoded as tests (see design, Testing)
+- [x] README rewritten for what v1 actually is; TESTING.md for the offline harness
+- [x] Release workflow: darwin-arm64 binary + checksum on GitHub Releases
 
 Exit: daemon survives reboot; a fresh machine could install from the release page.
 

--- a/src/api/contract.test.ts
+++ b/src/api/contract.test.ts
@@ -14,6 +14,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { createApiHandler } from "./server";
+import type { ApiDeps } from "./server";
 import { createApiClient } from "@/ui/api";
 import { saveMeta, saveRound } from "@/store/reviews";
 import { saveWatchList } from "@/store/watch-list";
@@ -47,9 +48,9 @@ function buildRequest(input: string, init?: RequestInit): Request {
   return new Request(input.startsWith("http") ? input : `${ORIGIN}${input}`, { ...init, headers });
 }
 
-/** A client whose transport is the real handler, not a hand-written fixture. */
-function clientOverHandler() {
-  const handler = createApiHandler({ lgtmDir, token: TOKEN, port: PORT, version: "test" });
+/** A client whose transport is the real handler, not a hand-written fixture. Extra deps splice in a live queue/quota/forge for the tests that need one. */
+function clientOverDeps(extra: Partial<ApiDeps> = {}) {
+  const handler = createApiHandler({ lgtmDir, token: TOKEN, port: PORT, version: "test", ...extra });
   return createApiClient({
     fetchImpl: (input, init) =>
       handler(buildRequest(input, init)),
@@ -57,6 +58,10 @@ function clientOverHandler() {
     location: { hash: "", pathname: "/", search: "" },
     history: { replaceState() {} },
   });
+}
+
+function clientOverHandler() {
+  return clientOverDeps();
 }
 
 /**
@@ -204,6 +209,20 @@ describe("GET /api/prs, daemon to browser", () => {
 
     expect(seen).toEqual(["failed", "queued", "reviewed", "reviewing", "skipped", "triage"]);
   });
+
+  test("a row's own key is the daemon's owner/repo#number, not something the browser has to reassemble", async () => {
+    // Reviews.tsx matches this row against the status queue's inFlightRounds
+    // / queuedEntries by this exact field (routes.ts's `formatRef`). Two
+    // independent spellings of the same identity, one built from `ref` here
+    // and another built from `owner`/`repo`/`number` on the browser side, is
+    // exactly the kind of drift this file exists to catch.
+    const ref = { owner: "acme", repo: "api", number: 42 };
+    await saveMeta(lgtmDir, ref, { state: "reviewing", author: "ada", headSha: "sha1" });
+
+    const pr = (await clientOverHandler().listPRs())[0]!;
+
+    expect(pr.key).toBe("acme/api#42");
+  });
 });
 
 /**
@@ -281,6 +300,81 @@ describe("the rest of the client surface", () => {
 
     expect(result.repo.owner).toBe("new");
     expect(result.entries).toHaveLength(1);
+  });
+});
+
+/**
+ * `/api/status`'s queue and quota detail, end to end.
+ *
+ * The browser client's status parser used to collapse the whole `queue`
+ * object into a single `queueLength` number and drop the rest. No view
+ * could tell a round twenty seconds in from one about to time out, or which
+ * PR held which of the concurrency slots. These pass a real `ApiDeps.queue`
+ * / `ApiDeps.quota` (the same shapes `daemon/queue.ts` and `daemon/quota.ts`
+ * actually produce) through the real route handler and the real client
+ * parser, so a shape change on either side fails here.
+ */
+describe("GET /api/status, daemon to browser: queue and quota detail", () => {
+  const QUEUED_AT = Date.parse("2026-08-30T00:01:00.000Z");
+  const STARTED_AT = Date.parse("2026-08-30T00:00:30.000Z");
+
+  function queueFake(pausedByGate = false): Pick<import("@/daemon/queue").ReviewQueue, "enqueue" | "remove" | "status"> {
+    return {
+      enqueue: () => "queued",
+      remove: () => false,
+      status: () => ({
+        queued: 1,
+        inFlight: 1,
+        pausedByGate,
+        queuedEntries: [{ ref: { owner: "acme", repo: "api", number: 9 }, headSha: "sha-queued", queuedAt: QUEUED_AT }],
+        inFlightRounds: [{ ref: { owner: "acme", repo: "api", number: 7 }, headSha: "sha-flight", startedAt: STARTED_AT }],
+      }),
+    };
+  }
+
+  function quotaFake(): { state: () => import("@/daemon/quota").QuotaState } {
+    return {
+      state: () => ({
+        mode: "throttled",
+        maxPercent: 82,
+        windows: [],
+        readAt: null,
+        resetAt: null,
+        consecutiveParseFailures: 0,
+        runsToday: 3,
+        dailyCap: 20,
+        lastError: null,
+      }),
+    };
+  }
+
+  test("in-flight rounds and queued entries arrive keyed, timed and matchable", async () => {
+    const status = await clientOverDeps({ queue: queueFake() }).status();
+
+    expect(status.queue.inFlightRounds).toEqual([
+      { key: "acme/api#7", headSha: "sha-flight", startedAt: new Date(STARTED_AT).toISOString() },
+    ]);
+    expect(status.queue.queuedEntries).toEqual([
+      { key: "acme/api#9", headSha: "sha-queued", queuedAt: new Date(QUEUED_AT).toISOString() },
+    ]);
+    // The flat convenience field other views still read stays correct too.
+    expect(status.queueLength).toBe(2);
+  });
+
+  test("pausedByGate, and the quota mode/percentage that explain it, all survive together", async () => {
+    const status = await clientOverDeps({ queue: queueFake(true), quota: quotaFake() }).status();
+
+    expect(status.queue.pausedByGate).toBe(true);
+    expect(status.quotaMode).toBe("throttled");
+    expect(status.quotaPercent).toBe(82);
+  });
+
+  test("with no queue or quota wired up, the client still gets a fully-shaped, empty queue rather than a hole", async () => {
+    const status = await clientOverHandler().status();
+
+    expect(status.queue).toEqual({ queued: 0, inFlight: 0, pausedByGate: false, queuedEntries: [], inFlightRounds: [] });
+    expect(status.quotaMode).toBe("ok");
+    expect(status.quotaPercent).toBeNull();
   });
 });
 

--- a/src/api/contract.test.ts
+++ b/src/api/contract.test.ts
@@ -321,6 +321,95 @@ describe("GET .../findings, daemon to browser", () => {
     expect(res.meta.title).toBe("Add a rate limiter");
   });
 
+  test("a round's session fields and its ready-made resume command arrive", async () => {
+    const ref = { owner: "acme", repo: "api", number: 101 };
+    await saveMeta(lgtmDir, ref, { state: "reviewed", headSha: "sha1", author: "ada" });
+    await saveRound(lgtmDir, {
+      ref,
+      round: 1,
+      agent: "reviewer",
+      provider: "claude-cli",
+      status: "ok",
+      headSha: "sha1",
+      startedAt: "2026-08-30T00:00:00.000Z",
+      durationMs: 1000,
+      findings: [{ severity: "high", file: "a.ts", line: 3, comment: "one" }],
+      sessionId: "sess-abc123",
+      sessionCwd: "/Users/ada/repos/api",
+      costUsd: 0.42,
+      turns: 7,
+    });
+
+    const res = await clientOverHandler().getFindings(ref);
+
+    expect(res.rounds).toHaveLength(1);
+    const round = res.rounds[0]!;
+    expect(round.sessionId).toBe("sess-abc123");
+    expect(round.sessionCwd).toBe("/Users/ada/repos/api");
+    expect(round.costUsd).toBe(0.42);
+    expect(round.turns).toBe(7);
+    // Built server-side, from the same sessionId and sessionCwd, so the
+    // client never has to reassemble it.
+    expect(round.resumeCommand).toBe("cd /Users/ada/repos/api && claude --resume sess-abc123");
+  });
+
+  test("resumeCommand omits the cd when the round carries no working directory", async () => {
+    const ref = { owner: "acme", repo: "api", number: 102 };
+    await saveMeta(lgtmDir, ref, { state: "reviewed", headSha: "sha1", author: "ada" });
+    await saveRound(lgtmDir, {
+      ref,
+      round: 1,
+      agent: "reviewer",
+      provider: "claude-cli",
+      status: "ok",
+      headSha: "sha1",
+      startedAt: "2026-08-30T00:00:00.000Z",
+      durationMs: 1000,
+      findings: [{ severity: "low", file: "a.ts", line: 1, comment: "one" }],
+      sessionId: "sess-xyz",
+      sessionCwd: null,
+    });
+
+    const res = await clientOverHandler().getFindings(ref);
+
+    expect(res.rounds[0]?.resumeCommand).toBe("claude --resume sess-xyz");
+  });
+
+  test("a round with no session id sends and parses a null resumeCommand, not a guessed one", async () => {
+    const ref = { owner: "acme", repo: "api", number: 103 };
+    await saveMeta(lgtmDir, ref, { state: "reviewed", headSha: "sha1", author: "ada" });
+    await saveRound(lgtmDir, {
+      ref,
+      round: 1,
+      agent: "reviewer",
+      provider: "claude-cli",
+      status: "ok",
+      headSha: "sha1",
+      startedAt: "2026-08-30T00:00:00.000Z",
+      durationMs: 1000,
+      findings: [{ severity: "low", file: "a.ts", line: 1, comment: "one" }],
+    });
+
+    // The raw wire shape, not the client's coercion, so a route that starts
+    // omitting the key entirely (rather than sending it as null) would still
+    // fail this rather than being smoothed over by the parser.
+    const handler = createApiHandler({ lgtmDir, token: TOKEN, port: PORT, version: "test" });
+    const raw = await handler(
+      buildRequest(`/api/prs/acme/api/103/findings`, { headers: { Authorization: `Bearer ${TOKEN}` } }),
+    );
+    const body = (await raw.json()) as { rounds: Array<Record<string, unknown>> };
+    expect(body.rounds[0]?.sessionId).toBeNull();
+    expect(body.rounds[0]?.resumeCommand).toBeNull();
+
+    const res = await clientOverHandler().getFindings(ref);
+    const round = res.rounds[0]!;
+    expect(round.sessionId).toBeNull();
+    expect(round.sessionCwd).toBeNull();
+    expect(round.costUsd).toBeNull();
+    expect(round.turns).toBeNull();
+    expect(round.resumeCommand).toBeNull();
+  });
+
   test("findings from several rounds all arrive", async () => {
     const ref = { owner: "acme", repo: "api", number: 100 };
     await saveMeta(lgtmDir, ref, { state: "reviewed", headSha: "s2", author: "ada" });

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -33,7 +33,7 @@ import fs from "fs/promises";
 import { postRoutes } from "./post";
 
 import { formatFindingKey, parseFindingKey } from "@/core";
-import type { CheckState, Finding, ForgeAdapter, PRMeta, PRRef, PRState, Severity } from "@/core";
+import type { CheckState, Finding, ForgeAdapter, PRMeta, PRRef, PRState, RoundFile, Severity } from "@/core";
 import { reviewsWhenReady } from "@/core/classify";
 import { parseDiff, sliceHunk } from "@/core/diff";
 import type { SlicedHunk } from "@/core/diff";
@@ -760,6 +760,21 @@ async function readSnapshot(
   return parsed;
 }
 
+/**
+ * `claude --resume <id>`, prefixed with a `cd` into the session's own
+ * working directory when one is known. The CLI files a session by the
+ * directory it ran in, so resuming from anywhere else finds nothing.
+ * Assembled once, here, so the browser has a string to copy rather than
+ * `sessionId` and `sessionCwd` to reassemble into a command of its own. Null
+ * when the round carries no session, which is every round file written
+ * before these fields existed.
+ */
+function resumeCommand(round: RoundFile): string | null {
+  if (!round.sessionId) return null;
+  const resume = `claude --resume ${round.sessionId}`;
+  return round.sessionCwd ? `cd ${round.sessionCwd} && ${resume}` : resume;
+}
+
 /** A permalink to the line as the round saw it, which a PR-files anchor cannot promise. */
 function findingUrl(ref: PRRef, sha: string, finding: Finding): string {
   if (!sha || !finding.file) return `${prUrl(ref)}/files`;
@@ -812,6 +827,13 @@ const findings: RouteHandler = async ({ params, deps }) => {
       startedAt: round.startedAt,
       durationMs: round.durationMs,
       hasSnapshot: diff !== null,
+      // The Provider run behind the round, straight off RoundFile: null for
+      // every round written before these fields existed, never an error.
+      sessionId: round.sessionId,
+      sessionCwd: round.sessionCwd,
+      costUsd: round.costUsd,
+      turns: round.turns,
+      resumeCommand: resumeCommand(round),
       findings: cards,
     });
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -124,6 +124,34 @@ export interface RoundFile {
   startedAt: string;
   durationMs: number;
   findings: Finding[];
+
+  // ── The Provider run behind the round ─────────────────────────────────
+  //
+  // All four are null for a round whose Provider reported none of them, and
+  // for every round file written before these fields existed. Null is a real
+  // answer here ("nothing was reported"), never a parse failure.
+
+  /**
+   * The Provider session that produced this round. The Claude CLI persists
+   * each print-mode session to disk and reopens it with
+   * `claude --resume <sessionId>`, so this is what lets a human carry on the
+   * conversation that wrote a finding rather than starting a new review to
+   * argue with it.
+   */
+  sessionId: string | null;
+
+  /**
+   * The directory the Provider ran in. Half of the session's address: the CLI
+   * files sessions by working directory, so a resume from anywhere else finds
+   * nothing. Useless on its own, and `sessionId` is useless without it.
+   */
+  sessionCwd: string | null;
+
+  /** What this round spent of the user's subscription, as the Provider reported it. */
+  costUsd: number | null;
+
+  /** How many turns the Provider took. */
+  turns: number | null;
 }
 
 // ─── PR metadata ────────────────────────────────────────────────────────────

--- a/src/daemon/cycle.test.ts
+++ b/src/daemon/cycle.test.ts
@@ -24,7 +24,15 @@ import {
 } from "@/core";
 import { reviewsWhenReady } from "@/core/classify";
 import { defaultAgentConfig, type AgentConfig, type ReviewInput, type ReviewOutcome } from "@/provider";
-import { diffSnapshotPath, loadAllRounds, loadMeta, reviewDir, saveMeta, saveRound } from "@/store/reviews";
+import {
+  diffSnapshotPath,
+  loadAllRounds,
+  loadMeta,
+  reviewDir,
+  saveMeta,
+  saveRound,
+  sessionsDir,
+} from "@/store/reviews";
 import { addToWatchList, loadWatchList, updateETag } from "@/store/watch-list";
 import type { DaemonEvent } from "./events";
 import type { QueueEntry } from "./queue";
@@ -1183,6 +1191,103 @@ function dispatchDeps(over: Partial<DispatchDeps> = {}): DispatchDeps {
     ...over,
   };
 }
+
+describe("dispatchReview: the session behind the round", () => {
+  const session = {
+    sessionId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    costUsd: 0.77,
+    turns: 14,
+  };
+
+  async function queued(): Promise<void> {
+    await saveMeta(store, ref(), { state: "queued", classification: "own", headSha: "sha1" });
+  }
+
+  test("spawns every Round from the one directory the store owns", async () => {
+    // Not a detail of the spawn. The CLI files its session under a slug of the
+    // working directory, so a Round started from wherever `lgtm up` happened
+    // to run leaves a session nobody can address.
+    await queued();
+    let seen: ReviewInput | null = null;
+
+    await dispatchReview(
+      entryFor(),
+      dispatchDeps({
+        review: async (given) => {
+          seen = given;
+          return outcome();
+        },
+      })
+    );
+
+    expect((seen as ReviewInput | null)?.sessionCwd).toBe(sessionsDir(store));
+    expect(await fs.exists(sessionsDir(store))).toBe(true);
+  });
+
+  test("records the session, the cost and the turns on the round file", async () => {
+    await queued();
+
+    await dispatchReview(
+      entryFor(),
+      dispatchDeps({ review: async () => outcome({ ...session, sessionCwd: sessionsDir(store) }) })
+    );
+
+    expect((await loadAllRounds(store, ref()))[0]).toMatchObject({
+      ...session,
+      sessionCwd: sessionsDir(store),
+    });
+  });
+
+  test("a failed Round records its session too", async () => {
+    // The review ran and only the reading of it failed, so the conversation
+    // is still there to be resumed and is worth more here than anywhere.
+    await queued();
+
+    await dispatchReview(
+      entryFor(),
+      dispatchDeps({
+        forge: { getPR: async () => detail(), getDiff: async () => "" },
+        review: async () =>
+          outcome({
+            ...session,
+            status: "failed",
+            findings: [],
+            error: "could not parse provider output",
+          }),
+      })
+    );
+
+    const round = (await loadAllRounds(store, ref()))[0];
+    expect(round).toMatchObject({ status: "failed", sessionId: session.sessionId });
+  });
+
+  test("a Provider that reports no session still records where the Round ran", async () => {
+    // The directory is ours to know either way, and a null session id is an
+    // honest answer rather than a failure.
+    await queued();
+
+    await dispatchReview(entryFor(), dispatchDeps({ review: async () => outcome() }));
+
+    expect((await loadAllRounds(store, ref()))[0]).toMatchObject({
+      sessionId: null,
+      costUsd: null,
+      turns: null,
+      sessionCwd: sessionsDir(store),
+    });
+  });
+
+  test("logs what the Round spent, when the Provider says", async () => {
+    await queued();
+    const lines: string[] = [];
+
+    await dispatchReview(
+      entryFor(),
+      dispatchDeps({ log: (line) => lines.push(line), review: async () => outcome(session) })
+    );
+
+    expect(lines.some((line) => line.includes("$0.77"))).toBe(true);
+  });
+});
 
 describe("dispatchReview", () => {
   test("writes the round, the snapshot, and the metadata", async () => {

--- a/src/daemon/cycle.ts
+++ b/src/daemon/cycle.ts
@@ -86,6 +86,7 @@ import {
   type ReviewOutcome,
 } from "@/provider";
 import {
+  ensureSessionsDir,
   loadAllRounds,
   loadMeta,
   listReviewedPRs,
@@ -882,6 +883,28 @@ async function resolveAgent(deps: DispatchDeps): Promise<AgentConfig> {
   return typeof deps.agent === "function" ? await deps.agent() : deps.agent;
 }
 
+/**
+ * The directory a Round is spawned from.
+ *
+ * One directory the store owns, for every Round of every PR. The Claude CLI
+ * files each session under a slug of the working directory it ran in, so a
+ * Round spawned from wherever `lgtm up` was started leaves its session
+ * somewhere nobody can name, and the resume command on the round file would be
+ * a guess. A fixed directory makes it a fact.
+ *
+ * A store that cannot be created here does not fail the Round. The review
+ * still runs, from the daemon's own working directory, and simply records no
+ * session directory to resume from.
+ */
+async function sessionCwdFor(deps: DispatchDeps): Promise<string | undefined> {
+  try {
+    return await ensureSessionsDir(deps.lgtmDir);
+  } catch (error) {
+    deps.log?.(`review: could not create the sessions directory: ${messageOf(error)}`);
+    return undefined;
+  }
+}
+
 async function runRound(
   deps: DispatchDeps,
   entry: QueueEntry,
@@ -902,6 +925,8 @@ async function runRound(
   await saveMeta(deps.lgtmDir, ref, { state: "reviewing" });
   emit(deps, { type: "pr-changed", ref });
 
+  const sessionCwd = await sessionCwdFor(deps);
+
   const startedAt = now();
   const run = deps.review ?? runReview;
   const outcome = await run({
@@ -909,6 +934,7 @@ async function runRound(
     prUrl: meta.url || prUrl(ref),
     binPath: deps.binPath?.() ?? undefined,
     priorFindings: priorFindingsFrom(priorRounds),
+    sessionCwd,
   });
 
   // The round file lands before the snapshot on purpose: pruning inside
@@ -925,6 +951,14 @@ async function runRound(
     durationMs: outcome.durationMs,
     findings: outcome.findings,
     raw: outcome.status === "failed" ? failureTranscript(outcome) : undefined,
+    // What it takes to reopen the conversation this Round had. The Provider
+    // echoes back the directory it ran in; the directory we asked for is the
+    // fallback, so a Provider that reports nothing still leaves the round
+    // pointing at the right place.
+    sessionId: outcome.sessionId ?? null,
+    sessionCwd: outcome.sessionCwd ?? sessionCwd ?? null,
+    costUsd: outcome.costUsd ?? null,
+    turns: outcome.turns ?? null,
   });
 
   if (outcome.status === "ok") {
@@ -950,7 +984,10 @@ async function runRound(
 
     deps.log?.(
       `review: ${label} round ${roundNumber} ok, ${outcome.findings.length} finding(s)` +
-        (outcome.dropped > 0 ? `, ${outcome.dropped} dropped` : "")
+        (outcome.dropped > 0 ? `, ${outcome.dropped} dropped` : "") +
+        // A Round spends the user's own subscription, so the log says what it
+        // spent whenever the Provider was willing to tell us.
+        (typeof outcome.costUsd === "number" ? `, $${outcome.costUsd.toFixed(2)}` : "")
     );
 
     if (outcome.findings.length > 0) emit(deps, { type: "findings-ready", ref });

--- a/src/provider/claude.test.ts
+++ b/src/provider/claude.test.ts
@@ -8,11 +8,34 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
 import { join } from "node:path";
 import { buildPrompt, claudeArgs, claudeProvider, DEFAULT_MODEL, run } from "./claude";
 import { defaultAgentConfig, type AgentConfig, type ReviewInput } from "./index";
 
 const SHIM = join(import.meta.dir, "../../test/fixtures/fake-claude.ts");
+
+/** The session the shim reports on every envelope it emits. */
+const SHIM_SESSION = {
+  sessionId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  costUsd: 0.77,
+  turns: 14,
+};
+
+/**
+ * An executable stand-in for the CLI, written to a scratch directory.
+ *
+ * Used where the shim cannot help: the tests below need a "binary" that
+ * reports the directory it was spawned in, or that prints an envelope whose
+ * result will not parse. Both are properties of the spawn, not of any review.
+ */
+async function fakeBinary(body: string): Promise<string> {
+  const dir = await fs.mkdtemp(join(os.tmpdir(), "lgtm-fake-cli-"));
+  const binPath = join(dir, "claude");
+  await fs.writeFile(binPath, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return binPath;
+}
 
 function agent(overrides: Partial<AgentConfig> = {}): AgentConfig {
   return { ...defaultAgentConfig(), severityFloor: "low", ...overrides };
@@ -152,6 +175,17 @@ describe("claudeArgs", () => {
 // ─── The spawn helper ───────────────────────────────────────────────────────
 
 describe("run", () => {
+  test("spawns in the working directory it is given", async () => {
+    // The Claude CLI files each session under a slug of its working
+    // directory, so this is the option that decides whether a Round can be
+    // resumed at all.
+    const dir = await fs.mkdtemp(join(os.tmpdir(), "lgtm-run-cwd-"));
+
+    const outcome = await run(["sh", "-c", "pwd"], { cwd: dir, timeoutSeconds: 10 });
+
+    expect(await fs.realpath(outcome.stdout.trim())).toBe(await fs.realpath(dir));
+  });
+
   test("returns stdout, stderr, and the exit code", async () => {
     const outcome = await run(["sh", "-c", "echo out; echo err >&2; exit 3"], {
       timeoutSeconds: 10,
@@ -284,5 +318,83 @@ describe("claudeProvider.review", () => {
     expect(outcome.status).toBe("failed");
     expect(outcome.error).toBeTruthy();
     expect(outcome.findings).toEqual([]);
+  });
+});
+
+// ─── The session behind the round ───────────────────────────────────────────
+
+describe("claudeProvider.review: session capture", () => {
+  test("carries the session, the cost and the turn count off the envelope", async () => {
+    // The session id is the whole feature: `claude --resume <id>` reopens this
+    // exact conversation, so a human can argue with the reviewer that wrote a
+    // finding instead of starting a fresh review.
+    process.env.FAKE_CLAUDE_MODE = "json";
+
+    const outcome = await claudeProvider.review(input());
+
+    expect(outcome).toMatchObject(SHIM_SESSION);
+  });
+
+  test("captures the session from the prose shape too, not only from JSON", async () => {
+    // The session lives on the envelope, which is there whatever shape the
+    // review text inside it takes.
+    process.env.FAKE_CLAUDE_MODE = "prose";
+
+    expect(await claudeProvider.review(input())).toMatchObject(SHIM_SESSION);
+  });
+
+  test("a provider that reports no session still reviews normally", async () => {
+    const binPath = await fakeBinary(`echo '{"result":"{\\"findings\\":[]}"}'`);
+
+    const outcome = await claudeProvider.review(input({ binPath }));
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.findings).toEqual([]);
+    expect(outcome).toMatchObject({ sessionId: null, costUsd: null, turns: null });
+  });
+
+  test("a round whose output would not parse keeps its session id", async () => {
+    // This is the round most worth resuming by hand: the review happened, and
+    // only the reading of it failed. Losing the id here would throw away the
+    // one thing that could recover the work.
+    const binPath = await fakeBinary(`echo '{"session_id":"sess-42","result":"I could not review this."}'`);
+
+    const outcome = await claudeProvider.review(input({ binPath }));
+
+    expect(outcome.status).toBe("failed");
+    expect(outcome.error).toBe("could not parse provider output");
+    expect(outcome.sessionId).toBe("sess-42");
+  });
+
+  test("spawns in the session directory it is given, and reports it back", async () => {
+    // Both halves of the resume address: the id says which session, the
+    // directory says where the CLI filed it.
+    const dir = await fs.mkdtemp(join(os.tmpdir(), "lgtm-sessions-"));
+    const probe = join(await fs.mkdtemp(join(os.tmpdir(), "lgtm-probe-")), "cwd.txt");
+    const binPath = await fakeBinary(
+      `pwd > "${probe}"\necho '{"session_id":"sess-1","result":"{\\"findings\\":[]}"}'`
+    );
+
+    const outcome = await claudeProvider.review(input({ binPath, sessionCwd: dir }));
+
+    expect(outcome.status).toBe("ok");
+    expect(outcome.sessionId).toBe("sess-1");
+    // What the round file records, and where the CLI actually ran, have to be
+    // the same directory or the resume command it prints is a lie.
+    expect(outcome.sessionCwd).toBe(dir);
+    const ranIn = (await fs.readFile(probe, "utf-8")).trim();
+    expect(await fs.realpath(ranIn)).toBe(await fs.realpath(dir));
+  });
+
+  test("no session directory is no session directory, not an invented one", async () => {
+    process.env.FAKE_CLAUDE_MODE = "json";
+
+    expect((await claudeProvider.review(input())).sessionCwd).toBeNull();
+  });
+
+  test("a round that never got as far as spawning reports no session", async () => {
+    const outcome = await claudeProvider.review(input({ binPath: "/nonexistent/claude" }));
+
+    expect(outcome).toMatchObject({ sessionId: null, costUsd: null, turns: null });
   });
 });

--- a/src/provider/claude.ts
+++ b/src/provider/claude.ts
@@ -13,10 +13,16 @@
  * anywhere above the working directory. And it inherits the session's default
  * model unless told otherwise, which cost twice as much for the same review,
  * so --model is never omitted here.
+ *
+ * The working directory still matters for a different reason. Print-mode
+ * sessions persist under ~/.claude/projects/<cwd-slug>/, keyed by where the
+ * CLI ran, and `claude --resume <session-id>` only finds one from the same
+ * place. So the daemon hands every Round one directory it owns, and the
+ * outcome reports both the id and the directory back.
  */
 
 import { formatFindingKey } from "@/core";
-import { extractFindings, validateFindings } from "./parse";
+import { extractFindings, extractSessionMeta, validateFindings, type SessionMeta } from "./parse";
 import type { AgentConfig, Provider, PriorFinding, ReviewInput, ReviewOutcome } from "./index";
 
 /**
@@ -188,6 +194,11 @@ function fromSpawn(outcome: SpawnOutcome, timeoutMinutes: number): { output: str
 async function review(input: ReviewInput): Promise<ReviewOutcome> {
   const startedAt = Date.now();
 
+  // Filled in from the envelope once the CLI has printed one. Until then the
+  // Round genuinely has no session, and every outcome below says so honestly
+  // rather than leaving the fields off.
+  let session: SessionMeta = { sessionId: null, costUsd: null, turns: null };
+
   const outcome = (
     findings: ReviewOutcome["findings"],
     raw: string,
@@ -201,6 +212,13 @@ async function review(input: ReviewInput): Promise<ReviewOutcome> {
     error,
     durationMs: Date.now() - startedAt,
     dropped,
+    sessionId: session.sessionId,
+    costUsd: session.costUsd,
+    turns: session.turns,
+    // Echoed back rather than assumed by the caller: this is where the CLI
+    // actually ran, and therefore the only directory a resume will find the
+    // session under.
+    sessionCwd: input.sessionCwd ?? null,
   });
 
   try {
@@ -209,7 +227,13 @@ async function review(input: ReviewInput): Promise<ReviewOutcome> {
 
     const spawned = await run(claudeArgs(input.agent, prompt, input.binPath), {
       timeoutSeconds: timeoutMinutes * 60,
+      cwd: input.sessionCwd,
     });
+
+    // Read before the failure branches below. A Round that timed out or whose
+    // output would not parse is exactly the one worth resuming by hand, so the
+    // session id is salvaged from whatever arrived, not only from a clean run.
+    session = extractSessionMeta(spawned.stdout);
 
     // Partial output after a timeout is kept as raw, so the failed Round has
     // something to dump next to it. It is not parsed: a truncated answer that

--- a/src/provider/index.test.ts
+++ b/src/provider/index.test.ts
@@ -62,6 +62,35 @@ describe("runReview", () => {
     expect(outcome.error).toContain("codex-cli");
     expect(outcome.findings).toEqual([]);
   });
+
+  test("a round that never ran reports no session, explicitly", async () => {
+    // Nothing was spawned, so there is nothing to resume. Saying so in full
+    // keeps the round file from carrying a half-written resume command.
+    const agent = { ...defaultAgentConfig(), provider: "codex-cli" } as unknown as AgentConfig;
+
+    expect(await runReview({ agent, prUrl: "https://github.com/acme/api/pull/42" })).toMatchObject({
+      sessionId: null,
+      sessionCwd: null,
+      costUsd: null,
+      turns: null,
+    });
+  });
+
+  test("hands the session directory to the Provider it dispatches to", async () => {
+    // The daemon owns the directory; this seam is the only thing between it
+    // and the spawn, so a dropped field here would silently scatter sessions.
+    process.env.FAKE_CLAUDE_MODE = "json";
+
+    const outcome = await runReview({
+      agent: { ...defaultAgentConfig(), severityFloor: "low" },
+      prUrl: "https://github.com/acme/api/pull/42",
+      binPath: SHIM,
+      sessionCwd: import.meta.dir,
+    });
+
+    expect(outcome.sessionCwd).toBe(import.meta.dir);
+    expect(outcome.sessionId).toBe("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+  });
 });
 
 describe("defaultAgentConfig", () => {

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -16,7 +16,15 @@ import type { FindingKey, Severity } from "@/core";
 import { claudeProvider, DEFAULT_MODEL } from "./claude";
 import type { RawFinding } from "./parse";
 
-export { extractFindings, validateFindings, meetsSeverity, SEVERITY_ORDER, type RawFinding } from "./parse";
+export {
+  extractFindings,
+  extractSessionMeta,
+  validateFindings,
+  meetsSeverity,
+  SEVERITY_ORDER,
+  type RawFinding,
+  type SessionMeta,
+} from "./parse";
 export { DEFAULT_MODEL } from "./claude";
 
 // ─── Agent configuration ────────────────────────────────────────────────────
@@ -95,6 +103,19 @@ export interface ReviewInput {
 
   /** Findings from earlier Rounds on this PR. */
   priorFindings?: PriorFinding[];
+
+  /**
+   * The directory the Provider is spawned in.
+   *
+   * Not a detail of the spawn. The CLI files each print-mode session under
+   * ~/.claude/projects/<cwd-slug>/, so the working directory is half the
+   * address of the session, and `claude --resume <id>` run from anywhere else
+   * will not find it. The daemon passes one stable directory it owns
+   * (`<lgtmDir>/sessions/`) so every Round's session is somewhere a human can
+   * be told about. Omitted, the Round runs wherever the daemon started and
+   * its session lands in an unpredictable slug.
+   */
+  sessionCwd?: string;
 }
 
 /**
@@ -120,6 +141,29 @@ export interface ReviewOutcome {
 
   /** Findings the Provider returned that were unusable or below the floor. */
   dropped: number;
+
+  // ── The run behind the Round ──────────────────────────────────────────
+  //
+  // Facts about the conversation that produced the Findings, not about the
+  // Findings themselves. All optional, and null when the Provider reported
+  // nothing: a Provider with no notion of a session, a cost, or a turn count
+  // is not a failed one, and a Round records what it was told and no more.
+
+  /**
+   * The Provider session, resumable with `claude --resume <id>` from
+   * `sessionCwd`. This is what lets a human pick up the conversation that
+   * wrote a finding instead of starting a fresh review to argue with it.
+   */
+  sessionId?: string | null;
+
+  /** What the Round spent of the user's own subscription. */
+  costUsd?: number | null;
+
+  /** How many turns the Provider took. */
+  turns?: number | null;
+
+  /** The directory the Provider ran in, without which `sessionId` is unusable. */
+  sessionCwd?: string | null;
 }
 
 /**
@@ -160,6 +204,10 @@ export async function runReview(input: ReviewInput): Promise<ReviewOutcome> {
       error: `unknown provider "${input.agent.provider}", expected one of ${PROVIDER_IDS.join(", ")}`,
       durationMs: 0,
       dropped: 0,
+      sessionId: null,
+      costUsd: null,
+      turns: null,
+      sessionCwd: null,
     };
   }
 

--- a/src/provider/parse.test.ts
+++ b/src/provider/parse.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { Severity } from "@/core";
-import { extractFindings, meetsSeverity, validateFindings } from "./parse";
+import { extractFindings, extractSessionMeta, meetsSeverity, validateFindings } from "./parse";
 
 // ─── extractFindings ────────────────────────────────────────────────────────
 
@@ -183,6 +183,121 @@ describe("extractFindings", () => {
   test("an explicit empty result is an empty array, not null", () => {
     expect(extractFindings('{"findings": []}')).toEqual([]);
     expect(extractFindings("[]")).toEqual([]);
+  });
+});
+
+// ─── extractSessionMeta ─────────────────────────────────────────────────────
+
+describe("extractSessionMeta", () => {
+  const one = { file: "src/a.ts", line: 1, severity: "high", comment: "boom" };
+
+  /** The envelope as the CLI actually prints it, findings and session both. */
+  function envelope(over: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 344_000,
+      session_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      total_cost_usd: 0.77,
+      num_turns: 14,
+      modelUsage: { "claude-sonnet-5": { inputTokens: 12, outputTokens: 34 } },
+      result: JSON.stringify({ findings: [one] }),
+      ...over,
+    });
+  }
+
+  test("reads the session, cost and turn count out of the envelope", () => {
+    expect(extractSessionMeta(envelope())).toEqual({
+      sessionId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      costUsd: 0.77,
+      turns: 14,
+    });
+  });
+
+  test("the session id is metadata, never a finding", () => {
+    // Both halves read the same envelope and neither may see the other's
+    // fields. A cost figure in the findings array would post to a PR.
+    const raw = envelope();
+
+    expect(extractFindings(raw)).toEqual([one]);
+    expect(extractSessionMeta(raw).sessionId).toBe("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+  });
+
+  test("a provider that reports no session parses normally and says nothing", () => {
+    // The whole point of keeping these apart: findings still come out, and the
+    // session reads as three honest nulls rather than a parse failure.
+    const raw = JSON.stringify({ findings: [one] });
+
+    expect(extractFindings(raw)).toEqual([one]);
+    expect(extractSessionMeta(raw)).toEqual({ sessionId: null, costUsd: null, turns: null });
+  });
+
+  test("reports whichever fields are there and nulls the rest", () => {
+    const raw = JSON.stringify({ session_id: "abc-123", result: "{}" });
+
+    expect(extractSessionMeta(raw)).toEqual({ sessionId: "abc-123", costUsd: null, turns: null });
+  });
+
+  test("finds the envelope behind a line of chatter", () => {
+    // Nothing promises the JSON is alone on stdout, and a Round whose session
+    // id is lost to a banner line cannot be resumed.
+    const raw = `Loading project settings...\n${envelope()}`;
+
+    expect(extractSessionMeta(raw).sessionId).toBe("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+  });
+
+  test("unparseable output is a session-less round, not a throw", () => {
+    // The garbage case still has to return: this is exactly the round that
+    // becomes a .raw.txt dump, and it must not take the provider down first.
+    for (const raw of ["", "   ", "This is not valid JSON: {broken [", "- `a.ts:1` — boom"]) {
+      expect(extractSessionMeta(raw)).toEqual({ sessionId: null, costUsd: null, turns: null });
+    }
+  });
+
+  test("an empty session id reads as none rather than as an id", () => {
+    expect(extractSessionMeta(JSON.stringify({ session_id: "   ", num_turns: 2 }))).toEqual({
+      sessionId: null,
+      costUsd: null,
+      turns: 2,
+    });
+  });
+
+  test("rejects a cost or turn count that cannot be true", () => {
+    // A negative cost or a fractional turn count is a misread field, and a
+    // wrong number here would be reported to the user as fact.
+    expect(extractSessionMeta(envelope({ total_cost_usd: -3, num_turns: 1.5 }))).toMatchObject({
+      costUsd: null,
+      turns: null,
+    });
+    expect(extractSessionMeta(envelope({ total_cost_usd: "free", num_turns: "many" }))).toMatchObject({
+      costUsd: null,
+      turns: null,
+    });
+  });
+
+  test("accepts the numbers as strings, which JSON emitters sometimes do", () => {
+    expect(extractSessionMeta(envelope({ total_cost_usd: "0.77", num_turns: "14" }))).toMatchObject({
+      costUsd: 0.77,
+      turns: 14,
+    });
+  });
+
+  test("a free round reports zero rather than nothing", () => {
+    // Zero and null are different answers: one is a measured cost, the other
+    // is a provider that did not say.
+    expect(extractSessionMeta(envelope({ total_cost_usd: 0, num_turns: 0 }))).toMatchObject({
+      costUsd: 0,
+      turns: 0,
+    });
+  });
+
+  test("a bare findings array carries no session, and looking for one is harmless", () => {
+    expect(extractSessionMeta(JSON.stringify([one]))).toEqual({
+      sessionId: null,
+      costUsd: null,
+      turns: null,
+    });
   });
 });
 

--- a/src/provider/parse.ts
+++ b/src/provider/parse.ts
@@ -13,6 +13,10 @@
  * the output" and becomes a failed Round with a .raw.txt dump, while an empty
  * array means "reviewed, found nothing". Collapsing them would report a broken
  * CLI as a clean PR.
+ *
+ * The envelope also carries facts about the run itself, which this module
+ * reads separately from the findings and never mixes into them: see
+ * `extractSessionMeta`.
  */
 
 import type { Severity } from "@/core";
@@ -237,6 +241,107 @@ function parseProseFindings(text: string): unknown[] {
   }
 
   return findings;
+}
+
+// ─── Session metadata ───────────────────────────────────────────────────────
+
+/**
+ * What the CLI reports about the run that produced a Round, beside its
+ * findings.
+ *
+ * `sessionId` is the one that pays for itself. Print-mode sessions persist to
+ * ~/.claude/projects/<cwd-slug>/<session-id>.jsonl, and `claude --resume
+ * <session-id>` reopens one with its full context, so a human who disagrees
+ * with a finding can ask the reviewer that wrote it rather than starting over.
+ * The cost and turn count are here because a Round spends the user's own
+ * subscription, and a Round that cost real money should be able to say so.
+ *
+ * Every field is null when the Provider did not report it. A Provider that
+ * reports none of them is not a failure and not a parse error; it is a
+ * Provider with nothing to say about its own run.
+ */
+export interface SessionMeta {
+  sessionId: string | null;
+  costUsd: number | null;
+  turns: number | null;
+}
+
+const NO_SESSION: SessionMeta = { sessionId: null, costUsd: null, turns: null };
+
+/** The CLI's own spelling first; camelCase in case a future release drifts. */
+const SESSION_ID_KEYS = ["session_id", "sessionId"];
+const COST_KEYS = ["total_cost_usd", "totalCostUsd", "cost_usd"];
+const TURN_KEYS = ["num_turns", "numTurns"];
+
+/**
+ * Read the session facts out of whatever the Provider printed.
+ *
+ * Deliberately separate from `extractFindings` rather than folded into it.
+ * These are metadata about the run, never a Finding, and the strategy chain
+ * that finds Findings must not start looking at cost figures. Keeping them
+ * apart also means a Provider that reports no session still parses exactly as
+ * it did before: this function answers all-nulls and nothing upstream cares.
+ *
+ * The envelope is normally the whole output, so that is tried first. The scan
+ * for an embedded object is what covers a CLI that prints a line of chatter
+ * before its JSON, which is cheap insurance for a shape nobody promised.
+ */
+export function extractSessionMeta(raw: string): SessionMeta {
+  const text = raw.trim();
+  if (!text) return { ...NO_SESSION };
+
+  const direct = tryParseJson(text);
+  if (direct !== undefined) {
+    const meta = sessionFrom(direct);
+    if (meta) return meta;
+  }
+
+  for (const candidate of embeddedJson(text)) {
+    const parsed = tryParseJson(candidate);
+    if (parsed === undefined) continue;
+    const meta = sessionFrom(parsed);
+    if (meta) return meta;
+  }
+
+  return { ...NO_SESSION };
+}
+
+/**
+ * One object's session facts, or null when it carries none of them.
+ *
+ * Null rather than an all-null SessionMeta, so the scan above can keep
+ * looking past an object that happened to parse but says nothing.
+ */
+function sessionFrom(value: unknown): SessionMeta | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
+
+  const sessionId = firstString(obj, SESSION_ID_KEYS);
+  const costUsd = firstNumber(obj, COST_KEYS, (n) => n >= 0);
+  const turns = firstNumber(obj, TURN_KEYS, (n) => Number.isInteger(n) && n >= 0);
+
+  if (sessionId === null && costUsd === null && turns === null) return null;
+  return { sessionId, costUsd, turns };
+}
+
+/** The first key that holds a usable number, accepting a numeric string too. */
+function firstNumber(
+  obj: Record<string, unknown>,
+  keys: string[],
+  accept: (value: number) => boolean
+): number | null {
+  for (const key of keys) {
+    const value = obj[key];
+
+    if (typeof value === "number" && Number.isFinite(value) && accept(value)) return value;
+
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed) && accept(parsed)) return parsed;
+    }
+  }
+
+  return null;
 }
 
 // ─── Validation ─────────────────────────────────────────────────────────────

--- a/src/store/reviews.test.ts
+++ b/src/store/reviews.test.ts
@@ -38,6 +38,7 @@ import path from "path";
 import { parseOKF, stringifyOKF } from "./okf.js";
 import {
   diffSnapshotPath,
+  ensureSessionsDir,
   listReviewedPRs,
   loadAllRounds,
   loadMeta,
@@ -53,6 +54,7 @@ import {
   reviewDir,
   saveMeta,
   saveRound,
+  sessionsDir,
   type SaveRoundInput,
 } from "./reviews.js";
 import type { Finding, PRRef } from "@/core";
@@ -561,6 +563,96 @@ describe("failed rounds", () => {
   });
 });
 
+// ─── The session behind a round ─────────────────────────────────────────────
+
+describe("session", () => {
+  const SESSION = {
+    sessionId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    sessionCwd: "/Users/someone/.lgtm-farm/sessions",
+    costUsd: 0.77,
+    turns: 14,
+  };
+
+  test("every round is spawned from one directory the store owns", async () => {
+    // The Claude CLI files sessions under a slug of the working directory it
+    // ran in, so this fixed name is what makes a session findable later.
+    expect(sessionsDir(store)).toBe(path.join(store, "sessions"));
+
+    expect(await ensureSessionsDir(store)).toBe(sessionsDir(store));
+    expect(await fs.exists(sessionsDir(store))).toBe(true);
+  });
+
+  test("creating the sessions directory twice is not an error", async () => {
+    // Every round calls it, so it has to be safe to call on an existing store.
+    await ensureSessionsDir(store);
+    await ensureSessionsDir(store);
+
+    expect(await fs.exists(sessionsDir(store))).toBe(true);
+  });
+
+  test("a round records the session, the directory, the cost and the turns", async () => {
+    await writeRound(ref, 1, "reviewer", [finding()], SESSION);
+
+    expect(await loadRound(store, ref, 1, "reviewer")).toMatchObject(SESSION);
+  });
+
+  test("the session lands in the frontmatter, where a human can read it", async () => {
+    await writeRound(ref, 1, "reviewer", [finding()], SESSION);
+
+    const { data } = parseOKF(
+      await fs.readFile(path.join(reviewDir(store, ref), "r1-reviewer.md"), "utf-8")
+    );
+
+    expect(data.sessionId).toBe(SESSION.sessionId);
+    expect(data.sessionCwd).toBe(SESSION.sessionCwd);
+    expect(data.costUsd).toBe(0.77);
+    expect(data.turns).toBe(14);
+  });
+
+  test("the body spells out the command that resumes the review", async () => {
+    // Both halves or nothing: run the resume from any other directory and the
+    // CLI reports no such session, so the cd is part of the instruction.
+    await writeRound(ref, 1, "reviewer", [finding()], SESSION);
+
+    const body = await fs.readFile(path.join(reviewDir(store, ref), "r1-reviewer.md"), "utf-8");
+
+    expect(body).toContain(
+      `cd ${SESSION.sessionCwd} && claude --resume ${SESSION.sessionId}`
+    );
+    expect(body).toContain("Cost: $0.77, 14 turn(s)");
+  });
+
+  test("a failed round says how to resume it too", async () => {
+    // The round most worth reopening by hand: the review ran, and only the
+    // reading of it failed.
+    await writeRound(ref, 1, "reviewer", [], { ...SESSION, status: "failed", raw: "not JSON" });
+
+    const body = await fs.readFile(path.join(reviewDir(store, ref), "r1-reviewer.md"), "utf-8");
+
+    expect(body).toContain("Review failed");
+    expect(body).toContain(`claude --resume ${SESSION.sessionId}`);
+  });
+
+  test("a round with no session says nothing about resuming", async () => {
+    await writeRound(ref, 1, "reviewer", [finding()]);
+
+    const round = (await loadRound(store, ref, 1, "reviewer"))!;
+    expect(round).toMatchObject({ sessionId: null, sessionCwd: null, costUsd: null, turns: null });
+
+    const body = await fs.readFile(path.join(reviewDir(store, ref), "r1-reviewer.md"), "utf-8");
+    expect(body).not.toContain("--resume");
+    expect(body).not.toContain("Cost:");
+  });
+
+  test("a round that cost nearly nothing still reports a number", async () => {
+    // Two decimals would round $0.0031 to $0.00 and read as free.
+    await writeRound(ref, 1, "reviewer", [finding()], { costUsd: 0.0031 });
+
+    const body = await fs.readFile(path.join(reviewDir(store, ref), "r1-reviewer.md"), "utf-8");
+    expect(body).toContain("Cost: $0.0031");
+  });
+});
+
 // ─── Hand-edited files ──────────────────────────────────────────────────────
 
 describe("hand-edited files", () => {
@@ -663,6 +755,75 @@ describe("hand-edited files", () => {
     // Not false. A hand-edit typo must not tell the user their PR conflicts.
     expect(meta.mergeable).toBeNull();
     expect(meta.checkStatus).toBeNull();
+  });
+
+  test("a round file written before sessions existed loads with them null", async () => {
+    // Exactly the shape every round file on disk already has. It must keep
+    // loading unchanged, with four honest nulls rather than a parse failure.
+    const dir = reviewDir(store, ref);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "r1-reviewer.md"),
+      stringifyOKF(
+        {
+          round: 1,
+          agent: "reviewer",
+          provider: "claude-cli",
+          status: "ok",
+          headSha: "abc123",
+          startedAt: "2026-08-29T10:00:00Z",
+          durationMs: 84210,
+          findings: [{ id: "f1", file: "src/limiter.ts", line: 118, severity: "high", comment: "boom", state: "open" }],
+        },
+        "# Round 1"
+      ),
+      "utf-8"
+    );
+
+    const round = (await loadRound(store, ref, 1, "reviewer"))!;
+
+    expect(round).toMatchObject({
+      round: 1,
+      agent: "reviewer",
+      status: "ok",
+      headSha: "abc123",
+      durationMs: 84210,
+      sessionId: null,
+      sessionCwd: null,
+      costUsd: null,
+      turns: null,
+    });
+    expect(round.findings[0]).toMatchObject({ id: "f1", file: "src/limiter.ts", state: "open" });
+  });
+
+  test("garbage in a session field reads as null, never as a resumable id", async () => {
+    // A round file claiming a session that does not exist would print a
+    // resume command that fails, which is worse than printing none.
+    const dir = reviewDir(store, ref);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "r1-reviewer.md"),
+      stringifyOKF(
+        {
+          round: 1,
+          agent: "reviewer",
+          sessionId: "   ",
+          sessionCwd: 42,
+          costUsd: "free",
+          turns: 2.5,
+          findings: [],
+        },
+        "body"
+      ),
+      "utf-8"
+    );
+
+    expect(await loadRound(store, ref, 1, "reviewer")).toMatchObject({
+      sessionId: null,
+      sessionCwd: null,
+      costUsd: null,
+      turns: null,
+    });
   });
 
   test("a corrupt round file is skipped rather than taking the PR down", async () => {

--- a/src/store/reviews.ts
+++ b/src/store/reviews.ts
@@ -86,6 +86,28 @@ export function diffSnapshotPath(lgtmDir: string, ref: PRRef, sha: string): stri
   return path.join(reviewDir(lgtmDir, ref), `diff-${sha}.patch`);
 }
 
+/**
+ * The one directory every Round is spawned from: `<lgtmDir>/sessions/`.
+ *
+ * Empty by design. Nothing of ours is written here; it exists to be a working
+ * directory with a fixed name. The Claude CLI files each print-mode session
+ * under a slug of the directory it ran in, so a Round spawned from wherever
+ * the daemon happened to start leaves its session under a slug nobody can
+ * predict, and `claude --resume <id>` from anywhere else finds nothing. One
+ * directory the store owns turns "resume this round" into a command that can
+ * be printed.
+ */
+export function sessionsDir(lgtmDir: string): string {
+  return path.join(lgtmDir, "sessions");
+}
+
+/** `sessionsDir`, created if it is not there yet. */
+export async function ensureSessionsDir(lgtmDir: string): Promise<string> {
+  const dir = sessionsDir(lgtmDir);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
 export function prUrl(ref: PRRef): string {
   return `https://github.com/${ref.owner}/${ref.repo}/pull/${ref.number}`;
 }
@@ -148,7 +170,29 @@ function normaliseFindings(value: unknown): Finding[] {
     .filter((f) => f.file && f.comment);
 }
 
+/** A non-empty string, or null. Anything else in the field reads as null. */
+function nullableString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/** A number at or above zero, or null. Rejects NaN, negatives and junk alike. */
+function nonNegativeNumber(value: unknown): number | null {
+  const parsed = nullableNumber(value);
+  return parsed !== null && parsed >= 0 ? parsed : null;
+}
+
+/**
+ * The four session fields all read the same way as the triage fields on
+ * meta.md: absent, hand-deleted, or garbage all come back null. Every round
+ * file written before these fields existed is exactly the "absent" case, so
+ * this is what keeps an older round loading unchanged rather than as a
+ * corrupt one.
+ */
 function parseRoundFileData(data: Record<string, unknown>): RoundFile {
+  const turns = nonNegativeNumber(data.turns);
+
   return {
     round: Number(data.round ?? 0),
     agent: String(data.agent ?? ""),
@@ -158,6 +202,10 @@ function parseRoundFileData(data: Record<string, unknown>): RoundFile {
     startedAt: String(data.startedAt ?? ""),
     durationMs: Number(data.durationMs ?? 0),
     findings: normaliseFindings(data.findings),
+    sessionId: nullableString(data.sessionId),
+    sessionCwd: nullableString(data.sessionCwd),
+    costUsd: nonNegativeNumber(data.costUsd),
+    turns: turns !== null && Number.isInteger(turns) ? turns : null,
   };
 }
 
@@ -234,6 +282,16 @@ export interface SaveRoundInput {
   findings: Array<Omit<Finding, "id" | "state" | "heldReason">>;
   /** Unparseable provider output. Written only when status is "failed", so a healthy round never leaves a transcript on disk. */
   raw?: string;
+
+  /**
+   * The Provider run behind this round. Optional at the call site and null on
+   * disk when omitted: a Provider that reports no session is not an error, and
+   * a caller that has nothing to say here should not have to say null.
+   */
+  sessionId?: string | null;
+  sessionCwd?: string | null;
+  costUsd?: number | null;
+  turns?: number | null;
 }
 
 /**
@@ -264,6 +322,10 @@ export async function saveRound(lgtmDir: string, input: SaveRoundInput): Promise
     startedAt: input.startedAt,
     durationMs: input.durationMs,
     findings,
+    sessionId: input.sessionId ?? null,
+    sessionCwd: input.sessionCwd ?? null,
+    costUsd: input.costUsd ?? null,
+    turns: input.turns ?? null,
   };
 
   const store = createOKFStore(lgtmDir);
@@ -280,6 +342,10 @@ export async function saveRound(lgtmDir: string, input: SaveRoundInput): Promise
 
 function roundBody(round: RoundFile): string {
   const lines = [`# Round ${round.round} — ${round.agent}${round.provider ? ` (${round.provider})` : ""}`, ""];
+
+  // Before the two early returns below, because a failed round is the one a
+  // human is most likely to want to reopen and ask about.
+  lines.push(...sessionLines(round));
 
   if (round.status === "failed") {
     lines.push("Review failed. See the .raw.txt file next to this one for the unparsed output.", "");
@@ -303,6 +369,38 @@ function roundBody(round: RoundFile): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * The resume command, spelled out, plus what the round cost.
+ *
+ * Written as one runnable line rather than two facts to assemble, because the
+ * `cd` is not optional trivia: run the resume from anywhere else and the CLI
+ * reports no such session. Nothing is printed when there is no session id,
+ * which is every round file written before this existed.
+ */
+function sessionLines(round: RoundFile): string[] {
+  const lines: string[] = [];
+
+  if (round.sessionId) {
+    const resume = `claude --resume ${round.sessionId}`;
+    lines.push(
+      `Resume this review: \`${round.sessionCwd ? `cd ${round.sessionCwd} && ${resume}` : resume}\``,
+      ""
+    );
+  }
+
+  const spent: string[] = [];
+  if (round.costUsd !== null) spent.push(formatUsd(round.costUsd));
+  if (round.turns !== null) spent.push(`${round.turns} turn(s)`);
+  if (spent.length > 0) lines.push(`Cost: ${spent.join(", ")}`, "");
+
+  return lines;
+}
+
+/** Two decimals, except where two decimals would round a real cost to $0.00. */
+function formatUsd(value: number): string {
+  return `$${value >= 0.01 ? value.toFixed(2) : value.toFixed(4)}`;
 }
 
 // ─── Meta ───────────────────────────────────────────────────────────────────

--- a/src/ui/api.ts
+++ b/src/ui/api.ts
@@ -161,6 +161,31 @@ export interface StatusCycleInfo {
 
 export type QuotaMode = "ok" | "throttled" | "fallback";
 
+/** One PR waiting for a slot, in the queue's own FIFO order. Index 0 is next. */
+export interface QueuedEntryInfo {
+  /** `owner/repo#number`, formatted by the daemon (routes.ts's `formatRef`). Match a PR row to this entry by this field, never by reassembling it from `owner`/`repo`/`number`. */
+  key: string;
+  headSha: string;
+  queuedAt: string;
+}
+
+/** One Round running right now, and the SHA it is actually reviewing. That can be newer than the PR's own `headSha`, per queue.ts's rule 3. */
+export interface InFlightRoundInfo {
+  key: string;
+  headSha: string;
+  startedAt: string;
+}
+
+/** The queue half of `GET /api/status` (design.md, "HTTP API"; src/daemon/queue.ts's `QueueSnapshot`). */
+export interface QueueStatus {
+  queued: number;
+  inFlight: number;
+  /** True when the last drain stopped because the quota gate said no. Every queued entry is held for that reason, not for lack of a slot. */
+  pausedByGate: boolean;
+  queuedEntries: QueuedEntryInfo[];
+  inFlightRounds: InFlightRoundInfo[];
+}
+
 export interface StatusResponse {
   uptimeMs: number;
   startedAt: string | null;
@@ -168,9 +193,13 @@ export interface StatusResponse {
   lastCycle: StatusCycleInfo | null;
   nextPollAt: string | null;
   queueLength: number;
+  /** The full queue detail behind `queueLength`, naming which PR is in which slot and since when. */
+  queue: QueueStatus;
   triageCount: number;
   awaitingGate: number;
   quotaMode: QuotaMode;
+  /** The highest usage percentage across every reported window, or null before the first reading (daemon/quota.ts's `QuotaState.maxPercent`). Explains a `pausedByGate` queue rather than leaving it looking like a stall. */
+  quotaPercent: number | null;
   claudePath: string | null;
   ghPath: string | null;
 }
@@ -191,6 +220,20 @@ export function totalFindings(counts: FindingCounts): number {
 
 /** One row of `GET /api/prs`: meta plus the triage metadata R2.5 asks the Reviews view to show. */
 export interface PRListItem {
+  /**
+   * `owner/repo#number`, exactly as the daemon formats it (routes.ts's
+   * `formatRef`, sent as `PRRow.key`). Use this to match a row against the
+   * status queue's `queuedEntries`/`inFlightRounds`. Never reassemble it
+   * from `owner`/`repo`/`number` client-side; see this file's module doc on
+   * why two spellings of the same identity is a recurring source of bugs
+   * here.
+   *
+   * Optional, not defaulted to a client-reconstructed value, for the same
+   * reason: a response that genuinely omits it must read as "no key to
+   * match on" (every queue lookup misses, degrading to the plain-text
+   * label), never as a guess assembled from the other fields.
+   */
+  key?: string;
   owner: string;
   repo: string;
   number: number;
@@ -433,6 +476,7 @@ function toPRListItem(raw: unknown): PRListItem {
   const ref = asRecord(rec.ref);
   const findings = asRecord(rec.findings);
   return {
+    key: str(rec.key),
     owner: str(ref.owner ?? rec.owner),
     repo: str(ref.repo ?? rec.repo),
     number: num(ref.number ?? rec.number),
@@ -490,6 +534,27 @@ function toFinding(raw: unknown): FindingWithContext {
     state: findingState(rec.state),
     heldReason: nullableStr(rec.heldReason),
     hunk: toSlicedHunk(rec.hunk),
+  };
+}
+
+function toQueuedEntry(raw: unknown): QueuedEntryInfo {
+  const rec = asRecord(raw);
+  return { key: str(rec.key), headSha: str(rec.headSha), queuedAt: str(rec.queuedAt) };
+}
+
+function toInFlightRound(raw: unknown): InFlightRoundInfo {
+  const rec = asRecord(raw);
+  return { key: str(rec.key), headSha: str(rec.headSha), startedAt: str(rec.startedAt) };
+}
+
+/** `rec` is already the `queue` object's own record, not the top-level status body. See the one call site in `toStatusResponse`. */
+function toQueueStatus(rec: Record<string, unknown>): QueueStatus {
+  return {
+    queued: num(rec.queued),
+    inFlight: num(rec.inFlight),
+    pausedByGate: rec.pausedByGate === true,
+    queuedEntries: Array.isArray(rec.queuedEntries) ? rec.queuedEntries.map(toQueuedEntry) : [],
+    inFlightRounds: Array.isArray(rec.inFlightRounds) ? rec.inFlightRounds.map(toInFlightRound) : [],
   };
 }
 
@@ -578,6 +643,7 @@ function toStatusResponse(raw: unknown): StatusResponse {
     return hit ? nullableStr(hit.path) : null;
   };
   const mode = quota.mode;
+  const queueStatus = toQueueStatus(queue);
 
   return {
     uptimeMs: num(rec.uptimeMs),
@@ -587,10 +653,12 @@ function toStatusResponse(raw: unknown): StatusResponse {
       ? { at: str(scheduler.lastCycleAt), outcome: cycle.status === "error" ? "error" : "ok" }
       : null,
     nextPollAt: nullableStr(scheduler.nextCycleAt),
-    queueLength: num(queue.queued) + num(queue.inFlight),
+    queueLength: queueStatus.queued + queueStatus.inFlight,
+    queue: queueStatus,
     triageCount: num(counts.triage),
     awaitingGate: num(counts.awaitingGate),
     quotaMode: mode === "throttled" || mode === "fallback" ? mode : "ok",
+    quotaPercent: nullableNum(quota.maxPercent),
     claudePath: pathOf("claude"),
     ghPath: pathOf("gh"),
   };

--- a/src/ui/api.ts
+++ b/src/ui/api.ts
@@ -263,9 +263,38 @@ export interface PRDetailMeta {
   draft: boolean;
 }
 
+/**
+ * One round's own metadata, as the findings route reports it beside that
+ * round's `findings[]`: what ran, and the Provider session behind it.
+ *
+ * The four session fields are null for a round whose Provider reported none
+ * of them, and for every round file written before they existed. An older
+ * round still parses, it just has nothing to resume. `resumeCommand` is the
+ * server's own `claude --resume <id>` (with its `cd` when the session's
+ * working directory is known), never reassembled from `sessionId` and
+ * `sessionCwd` here: routes.ts owns that one definition.
+ */
+export interface RoundSummary {
+  round: number;
+  agent: string;
+  provider: string;
+  status: "ok" | "failed";
+  headSha: string;
+  startedAt: string;
+  durationMs: number;
+  hasSnapshot: boolean;
+  sessionId: string | null;
+  sessionCwd: string | null;
+  costUsd: number | null;
+  turns: number | null;
+  resumeCommand: string | null;
+}
+
 export interface PRFindingsResponse {
   meta: PRDetailMeta;
   findings: FindingWithContext[];
+  /** Oldest round first, same order the daemon sends `rounds` in. */
+  rounds: RoundSummary[];
 }
 
 export type PRDecisionAction = "review" | "skip" | "unskip" | "review-anyway";
@@ -464,6 +493,30 @@ function toFinding(raw: unknown): FindingWithContext {
   };
 }
 
+function roundStatus(value: unknown): "ok" | "failed" {
+  return value === "failed" ? "failed" : "ok";
+}
+
+/** One round's metadata, read the same lenient way as everything else here: a field this round predates comes back null, not thrown. */
+function toRoundSummary(raw: unknown): RoundSummary {
+  const rec = asRecord(raw);
+  return {
+    round: num(rec.round),
+    agent: str(rec.agent),
+    provider: str(rec.provider),
+    status: roundStatus(rec.status),
+    headSha: str(rec.headSha),
+    startedAt: str(rec.startedAt),
+    durationMs: num(rec.durationMs),
+    hasSnapshot: rec.hasSnapshot === true,
+    sessionId: nullableStr(rec.sessionId),
+    sessionCwd: nullableStr(rec.sessionCwd),
+    costUsd: nullableNum(rec.costUsd),
+    turns: nullableNum(rec.turns),
+    resumeCommand: nullableStr(rec.resumeCommand),
+  };
+}
+
 function toPRDetailMeta(raw: unknown): PRDetailMeta {
   const rec = asRecord(raw);
   return {
@@ -494,17 +547,18 @@ function toPRDetailMeta(raw: unknown): PRDetailMeta {
  */
 function toPRFindingsResponse(raw: unknown): PRFindingsResponse {
   const rec = asRecord(raw);
-  const rounds = Array.isArray(rec.rounds) ? rec.rounds : [];
-  const nested = rounds.flatMap((round) => {
+  const roundsRaw = Array.isArray(rec.rounds) ? rec.rounds : [];
+  const nested = roundsRaw.flatMap((round) => {
     const list = asRecord(round).findings;
     return Array.isArray(list) ? list : [];
   });
   const flat = Array.isArray(rec.findings) ? rec.findings : [];
   const findings = (nested.length > 0 ? nested : flat).map(toFinding);
+  const rounds = roundsRaw.map(toRoundSummary);
 
   // `ref` holds owner/repo/number; `pr` holds everything else about it.
   const meta = { ...asRecord(rec.ref), ...asRecord(rec.pr ?? rec.meta) };
-  return { meta: toPRDetailMeta(meta), findings };
+  return { meta: toPRDetailMeta(meta), findings, rounds };
 }
 
 function toStatusResponse(raw: unknown): StatusResponse {

--- a/src/ui/hooks.ts
+++ b/src/ui/hooks.ts
@@ -286,6 +286,60 @@ function useInvalidationSignal(): number {
   return signal;
 }
 
+// ─── Ticking clock (elapsed-time labels, no React) ─────────────────────────
+//
+// The SSE stream carries invalidation hints, never a notion of time passing
+// (see the module doc), so a round's elapsed-time label would otherwise only
+// advance when something else happens to trigger a refetch: the daemon's own
+// poll, or another PR's status changing. A round that just started and one
+// about to time out would print the same stale number between those events.
+// This is the same split as `createEventStream`/`useConnectionStatus` above.
+// The scheduling itself (`createTicker`) is a plain, non-React function, so
+// its firing and its `stop()` cancellation can be asserted directly. The
+// hook wrapping it is untested at that layer, for the same reason
+// `useConnectionStatus` is. renderToStaticMarkup never runs effects (see
+// ui.test.ts's "no DOM globals" note).
+
+export interface TickerHandle {
+  stop(): void;
+}
+
+/** Same shape as `EventStreamOptions.setTimer`: real timer by default, a fake in tests, always returning its own canceller. */
+export type IntervalTimer = (fn: () => void, ms: number) => () => void;
+
+function realInterval(fn: () => void, ms: number): () => void {
+  const id = setInterval(fn, ms);
+  return () => clearInterval(id);
+}
+
+/** Calls `onTick` every `intervalMs` until `stop()`. The one place `setInterval` is named in this module. */
+export function createTicker(onTick: () => void, intervalMs: number, setTimer: IntervalTimer = realInterval): TickerHandle {
+  const cancel = setTimer(onTick, intervalMs);
+  return { stop: cancel };
+}
+
+/**
+ * The current time, re-read every `intervalMs` while `enabled`. The component
+ * that calls this owns the ticker: mounting (with `enabled`) starts it,
+ * unmounting or `enabled` going false clears it via the effect's own cleanup,
+ * so nothing keeps ticking once the last elapsed-time row using it is gone.
+ *
+ * `enabled` exists so a view with nothing currently in flight is not woken up
+ * once a second for no reason. Pass `false` and this hook holds its last
+ * value instead of scheduling anything.
+ */
+export function useTick(intervalMs: number, enabled = true): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!enabled) return;
+    const ticker = createTicker(() => setNow(Date.now()), intervalMs);
+    return () => ticker.stop();
+  }, [intervalMs, enabled]);
+
+  return now;
+}
+
 // ─── Data hooks ─────────────────────────────────────────────────────────────
 
 export interface AsyncState<T> {

--- a/src/ui/ui.test.ts
+++ b/src/ui/ui.test.ts
@@ -37,6 +37,7 @@ import {
 } from "./api";
 import {
   createEventStream,
+  createTicker,
   type ConnectionStatus,
   type EventSourceLike,
   type InvalidationHint,
@@ -44,12 +45,20 @@ import {
 import { FindingCard, type FindingCardProps } from "./components/FindingCard";
 import {
   CLOSED_FILTERS,
+  DEFAULT_ROUND_TIMEOUT_MS,
+  elapsedMs,
   filterToQuery,
+  formatDuration,
+  quotaReason,
+  reviewProgressFor,
   Reviews,
+  shortSha,
   STATUS_FILTERS,
+  timeoutUrgency,
   type ClosedFilter,
   type StatusFilter,
 } from "./views/Reviews";
+import type { PRListItem, StatusResponse } from "./api";
 import { PRDetail, RoundSession, type RoundSessionProps } from "./views/PRDetail";
 
 // ─── Stubs ──────────────────────────────────────────────────────────────────
@@ -350,6 +359,107 @@ describe("createApiClient", () => {
   });
 });
 
+// ─── api.ts: status(), the queue detail ─────────────────────────────────────
+//
+// This is the parser this task was asked to fix. It used to reduce the whole
+// `queue` object to a single `queueLength` number and drop everything else,
+// which is exactly what made a running review indistinguishable from a
+// queued one.
+// These pin the full shape down against a hand-built payload; the same shape
+// coming out of the real route handler is covered in contract.test.ts.
+
+function statusPayload(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    uptimeMs: 1000,
+    startedAt: "2026-08-30T00:00:00.000Z",
+    scheduler: { intervalMinutes: 15 },
+    queue: {
+      queued: 1,
+      inFlight: 2,
+      pausedByGate: false,
+      queuedEntries: [{ key: "acme/api#9", headSha: "sha-queued", queuedAt: "2026-08-30T00:01:00.000Z" }],
+      inFlightRounds: [{ key: "acme/api#7", headSha: "sha-flight", startedAt: "2026-08-30T00:00:30.000Z" }],
+    },
+    quota: { mode: "throttled", maxPercent: 82 },
+    counts: {},
+    ...overrides,
+  };
+}
+
+async function statusOf(payload: unknown) {
+  const client = createApiClient({
+    fetchImpl: async () => json(payload),
+    storage: memoryStorage(),
+    location: stubLocation("#t=tok"),
+    history: stubHistory(),
+  });
+  return client.status();
+}
+
+describe("createApiClient: status(), the queue detail", () => {
+  test("carries the in-flight rounds through, keyed and timed", async () => {
+    const status = await statusOf(statusPayload());
+
+    expect(status.queue.inFlightRounds).toEqual([
+      { key: "acme/api#7", headSha: "sha-flight", startedAt: "2026-08-30T00:00:30.000Z" },
+    ]);
+  });
+
+  test("carries the queued entries through, in the daemon's own FIFO order", async () => {
+    const status = await statusOf(statusPayload());
+
+    expect(status.queue.queuedEntries).toEqual([
+      { key: "acme/api#9", headSha: "sha-queued", queuedAt: "2026-08-30T00:01:00.000Z" },
+    ]);
+  });
+
+  test("pausedByGate arrives as an explicit boolean, not inferred from an empty queue", async () => {
+    const status = await statusOf(
+      statusPayload({
+        queue: { queued: 1, inFlight: 0, pausedByGate: true, queuedEntries: [], inFlightRounds: [] },
+      }),
+    );
+    expect(status.queue.pausedByGate).toBe(true);
+  });
+
+  test("the quota mode and percentage both survive, to explain a paused queue", async () => {
+    const status = await statusOf(statusPayload());
+    expect(status.quotaMode).toBe("throttled");
+    expect(status.quotaPercent).toBe(82);
+  });
+
+  test("quotaPercent is null before any usage reading exists, not coerced to zero", async () => {
+    const status = await statusOf(statusPayload({ quota: { mode: "ok", maxPercent: null } }));
+    expect(status.quotaPercent).toBeNull();
+  });
+
+  test("the flat queueLength convenience field still works, for views that only read that", async () => {
+    const status = await statusOf(statusPayload());
+    expect(status.queueLength).toBe(3); // 1 queued + 2 in flight
+  });
+
+  test("a status with no queue at all degrades to an empty, fully-shaped queue rather than throwing", async () => {
+    const status = await statusOf(statusPayload({ queue: null }));
+    expect(status.queue).toEqual({ queued: 0, inFlight: 0, pausedByGate: false, queuedEntries: [], inFlightRounds: [] });
+    expect(status.queueLength).toBe(0);
+  });
+
+  test("a queue entry missing a field degrades that field, not the whole row", async () => {
+    const status = await statusOf(
+      statusPayload({
+        queue: {
+          queued: 0,
+          inFlight: 1,
+          pausedByGate: false,
+          queuedEntries: [],
+          inFlightRounds: [{ key: "acme/api#7" /* headSha, startedAt absent */ }],
+        },
+      }),
+    );
+    expect(status.queue.inFlightRounds).toEqual([{ key: "acme/api#7", headSha: "", startedAt: "" }]);
+  });
+});
+
 // ─── api.ts: getFindings' round parser ──────────────────────────────────────
 //
 // The daemon nests findings under `rounds[].findings[]`, not under a flat
@@ -577,6 +687,241 @@ describe("Reviews.filterToQuery", () => {
   test("in-review means queued or reviewing, not failed — failed is its own filter", () => {
     const filter = filterToQuery("in-review", "exclude");
     expect(filter.state).toEqual(["queued", "reviewing"]);
+  });
+});
+
+// ─── Reviews: live review progress ──────────────────────────────────────────
+//
+// `reviewProgressFor` is the one place a PR row is matched to the status
+// payload's queue detail. That is the whole point of this task, and the one
+// most likely to silently show the wrong PR's progress on the wrong row if
+// the matching key is ever built two different ways. Every test below
+// matches by `key`, never by array position or headSha, on purpose.
+
+function basePR(overrides: Partial<PRListItem> = {}): PRListItem {
+  return {
+    key: "acme/api#7",
+    owner: "acme",
+    repo: "api",
+    number: 7,
+    url: "https://github.com/acme/api/pull/7",
+    title: "Add a rate limiter",
+    author: "ada",
+    state: "reviewing",
+    classification: "own",
+    draft: false,
+    headSha: "deadbeef",
+    createdAt: null,
+    closedAt: null,
+    pendingReviewId: null,
+    failedAttempts: 0,
+    additions: null,
+    deletions: null,
+    changedFiles: null,
+    mergeable: null,
+    checkStatus: null,
+    findingCounts: emptyFindingCounts(),
+    ...overrides,
+  };
+}
+
+function baseStatus(overrides: Partial<StatusResponse> = {}): StatusResponse {
+  return {
+    uptimeMs: 0,
+    startedAt: null,
+    intervalMinutes: 15,
+    lastCycle: null,
+    nextPollAt: null,
+    queueLength: 0,
+    queue: { queued: 0, inFlight: 0, pausedByGate: false, queuedEntries: [], inFlightRounds: [] },
+    triageCount: 0,
+    awaitingGate: 0,
+    quotaMode: "ok",
+    quotaPercent: null,
+    claudePath: null,
+    ghPath: null,
+    ...overrides,
+  };
+}
+
+describe("shortSha", () => {
+  test("takes the first 7 characters, GitHub's own short-ref length", () => {
+    expect(shortSha("deadbeef1234567")).toBe("deadbee");
+  });
+
+  test("an empty SHA renders as a dash, not as an empty string", () => {
+    expect(shortSha("")).toBe("—");
+  });
+});
+
+describe("elapsedMs", () => {
+  test("the difference between now and startedAt", () => {
+    expect(elapsedMs("2026-08-30T00:00:00.000Z", new Date("2026-08-30T00:02:00.000Z").getTime())).toBe(120_000);
+  });
+
+  test("a malformed timestamp reads as zero elapsed, not NaN or a thrown error", () => {
+    expect(elapsedMs("not a date", 1_000_000)).toBe(0);
+  });
+
+  test("clock skew that puts startedAt after now clamps to zero, never negative", () => {
+    expect(elapsedMs("2026-08-30T00:05:00.000Z", new Date("2026-08-30T00:00:00.000Z").getTime())).toBe(0);
+  });
+});
+
+describe("formatDuration", () => {
+  test("under a minute prints seconds only", () => {
+    expect(formatDuration(45_000)).toBe("45s");
+  });
+
+  test("a minute or more prints minutes and seconds", () => {
+    expect(formatDuration(134_000)).toBe("2m 14s");
+  });
+
+  test("exactly the default timeout", () => {
+    expect(formatDuration(DEFAULT_ROUND_TIMEOUT_MS)).toBe("10m 0s");
+  });
+});
+
+describe("timeoutUrgency", () => {
+  test("well under the timeout is normal", () => {
+    expect(timeoutUrgency(60_000, 600_000)).toBe("normal");
+  });
+
+  test("80% of the timeout is where near starts", () => {
+    expect(timeoutUrgency(480_000, 600_000)).toBe("near");
+    expect(timeoutUrgency(479_000, 600_000)).toBe("normal");
+  });
+
+  test("at or past the timeout is over", () => {
+    expect(timeoutUrgency(600_000, 600_000)).toBe("over");
+    expect(timeoutUrgency(700_000, 600_000)).toBe("over");
+  });
+});
+
+describe("quotaReason", () => {
+  test("throttled with a reading names the percentage", () => {
+    expect(quotaReason("throttled", 82)).toBe("throttled at 82%");
+  });
+
+  test("throttled with no reading yet still says so, without inventing a number", () => {
+    expect(quotaReason("throttled", null)).toBe("throttled");
+  });
+
+  test("fallback explains itself as the daily-cap gate, not as a generic pause", () => {
+    expect(quotaReason("fallback", null)).toBe("usage unreadable, gating on the daily cap");
+  });
+});
+
+describe("reviewProgressFor", () => {
+  const now = new Date("2026-08-30T00:10:00.000Z").getTime();
+
+  test("a reviewing PR matched by key reports elapsed time against the timeout", () => {
+    const status = baseStatus({
+      queue: {
+        queued: 0,
+        inFlight: 1,
+        pausedByGate: false,
+        queuedEntries: [],
+        inFlightRounds: [{ key: "acme/api#7", headSha: "sha-current", startedAt: "2026-08-30T00:08:00.000Z" }],
+      },
+    });
+
+    const progress = reviewProgressFor(basePR({ state: "reviewing" }), status, now);
+
+    expect(progress).toEqual({
+      kind: "reviewing",
+      headSha: "sha-current",
+      elapsedMs: 120_000,
+      timeoutMs: DEFAULT_ROUND_TIMEOUT_MS,
+      urgency: "normal",
+    });
+  });
+
+  test("matches by key, not by array position or by headSha, since either would show the wrong PR's progress", () => {
+    const status = baseStatus({
+      queue: {
+        queued: 0,
+        inFlight: 2,
+        pausedByGate: false,
+        queuedEntries: [],
+        inFlightRounds: [
+          { key: "acme/other#1", headSha: "deadbeef", startedAt: "2026-08-30T00:09:59.000Z" }, // same headSha as the PR below, wrong PR
+          { key: "acme/api#7", headSha: "sha-mine", startedAt: "2026-08-30T00:07:00.000Z" },
+        ],
+      },
+    });
+
+    const progress = reviewProgressFor(basePR({ state: "reviewing", headSha: "deadbeef" }), status, now);
+
+    expect(progress).toMatchObject({ kind: "reviewing", headSha: "sha-mine", elapsedMs: 180_000 });
+  });
+
+  test("a reviewing PR with no matching in-flight round is unmatched, not a guess", () => {
+    const status = baseStatus();
+    expect(reviewProgressFor(basePR({ state: "reviewing" }), status, now)).toEqual({ kind: "unmatched" });
+  });
+
+  test("a queued PR reports its 1-based position and the queue's total", () => {
+    const status = baseStatus({
+      queue: {
+        queued: 3,
+        inFlight: 0,
+        pausedByGate: false,
+        queuedEntries: [
+          { key: "acme/api#1", headSha: "s1", queuedAt: "2026-08-30T00:00:00.000Z" },
+          { key: "acme/api#7", headSha: "s7", queuedAt: "2026-08-30T00:01:00.000Z" },
+          { key: "acme/api#9", headSha: "s9", queuedAt: "2026-08-30T00:02:00.000Z" },
+        ],
+        inFlightRounds: [],
+      },
+    });
+
+    const progress = reviewProgressFor(basePR({ state: "queued" }), status, now);
+
+    expect(progress).toEqual({ kind: "queued", headSha: "s7", position: 2, total: 3 });
+  });
+
+  test("pausedByGate turns every queued row into a gate explanation, with the quota mode and percent carried along", () => {
+    const status = baseStatus({
+      quotaMode: "throttled",
+      quotaPercent: 91,
+      queue: {
+        queued: 1,
+        inFlight: 0,
+        pausedByGate: true,
+        queuedEntries: [{ key: "acme/api#7", headSha: "s7", queuedAt: "2026-08-30T00:01:00.000Z" }],
+        inFlightRounds: [],
+      },
+    });
+
+    const progress = reviewProgressFor(basePR({ state: "queued" }), status, now);
+
+    expect(progress).toEqual({
+      kind: "paused",
+      headSha: "s7",
+      position: 1,
+      total: 1,
+      quotaMode: "throttled",
+      quotaPercent: 91,
+    });
+  });
+
+  test("a queued PR with no matching entry is unmatched", () => {
+    expect(reviewProgressFor(basePR({ state: "queued" }), baseStatus(), now)).toEqual({ kind: "unmatched" });
+  });
+
+  test("a PR that is neither queued nor reviewing is always unmatched, whatever the queue holds", () => {
+    const status = baseStatus({
+      queue: {
+        queued: 0,
+        inFlight: 1,
+        pausedByGate: false,
+        queuedEntries: [],
+        inFlightRounds: [{ key: "acme/api#7", headSha: "s7", startedAt: "2026-08-30T00:00:00.000Z" }],
+      },
+    });
+
+    expect(reviewProgressFor(basePR({ state: "failed" }), status, now)).toEqual({ kind: "unmatched" });
   });
 });
 
@@ -812,6 +1157,57 @@ describe("createEventStream", () => {
       }),
     ).not.toThrow();
     expect(statuses).toEqual(["closed"]);
+  });
+});
+
+// ─── hooks.ts: createTicker ─────────────────────────────────────────────────
+
+describe("createTicker", () => {
+  test("schedules onTick with the given interval, through the injected timer", () => {
+    const scheduled: Array<{ fn: () => void; ms: number }> = [];
+    createTicker(
+      () => {},
+      1000,
+      (fn, ms) => {
+        scheduled.push({ fn, ms });
+        return () => {};
+      },
+    );
+
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.ms).toBe(1000);
+  });
+
+  test("firing the injected timer calls onTick, as many times as it fires", () => {
+    let fire: (() => void) | null = null;
+    let ticks = 0;
+    createTicker(
+      () => {
+        ticks += 1;
+      },
+      1000,
+      (fn) => {
+        fire = fn;
+        return () => {};
+      },
+    );
+
+    fire!();
+    fire!();
+    fire!();
+
+    expect(ticks).toBe(3);
+  });
+
+  test("stop() calls the timer's own canceller, exactly once", () => {
+    let cancelled = 0;
+    const ticker = createTicker(() => {}, 500, () => () => {
+      cancelled += 1;
+    });
+
+    ticker.stop();
+
+    expect(cancelled).toBe(1);
   });
 });
 

--- a/src/ui/ui.test.ts
+++ b/src/ui/ui.test.ts
@@ -50,7 +50,7 @@ import {
   type ClosedFilter,
   type StatusFilter,
 } from "./views/Reviews";
-import { PRDetail } from "./views/PRDetail";
+import { PRDetail, RoundSession, type RoundSessionProps } from "./views/PRDetail";
 
 // ─── Stubs ──────────────────────────────────────────────────────────────────
 
@@ -347,6 +347,115 @@ describe("createApiClient", () => {
     });
 
     expect(client.eventsUrl()).toBe("/api/events");
+  });
+});
+
+// ─── api.ts: getFindings' round parser ──────────────────────────────────────
+//
+// The daemon nests findings under `rounds[].findings[]`, not under a flat
+// `findings` key (see the contract tests in src/api/contract.test.ts for the
+// real route handler feeding the real parser). These stub the same shape by
+// hand to pin down the parser's own leniency: a round missing the session
+// fields entirely, not just carrying them as null, must still parse into a
+// PRDetail that renders.
+
+describe("createApiClient: getFindings, round parsing", () => {
+  test("reads a round's session fields and the server's own resumeCommand", async () => {
+    const client = createApiClient({
+      fetchImpl: async () =>
+        json({
+          ref: { owner: "acme", repo: "api", number: 42 },
+          pr: { title: "Add a rate limiter", author: "ada", headSha: "sha1" },
+          rounds: [
+            {
+              round: 1,
+              agent: "reviewer",
+              provider: "claude-cli",
+              status: "ok",
+              headSha: "sha1",
+              startedAt: "2026-08-30T00:00:00.000Z",
+              durationMs: 1000,
+              hasSnapshot: true,
+              sessionId: "sess-1",
+              sessionCwd: "/Users/ada/api",
+              costUsd: 0.42,
+              turns: 7,
+              resumeCommand: "cd /Users/ada/api && claude --resume sess-1",
+              findings: [
+                {
+                  key: "r1:reviewer:f1",
+                  round: 1,
+                  agent: "reviewer",
+                  headSha: "sha1",
+                  severity: "high",
+                  file: "a.ts",
+                  line: 3,
+                  comment: "one",
+                  state: "open",
+                },
+              ],
+            },
+          ],
+        }),
+      storage: memoryStorage(),
+      location: stubLocation("#t=tok"),
+      history: stubHistory(),
+    });
+
+    const res = await client.getFindings({ owner: "acme", repo: "api", number: 42 });
+
+    expect(res.rounds).toHaveLength(1);
+    expect(res.rounds[0]).toMatchObject({
+      round: 1,
+      agent: "reviewer",
+      sessionId: "sess-1",
+      sessionCwd: "/Users/ada/api",
+      costUsd: 0.42,
+      turns: 7,
+      resumeCommand: "cd /Users/ada/api && claude --resume sess-1",
+    });
+    expect(res.findings).toHaveLength(1);
+  });
+
+  test("a round with none of the five fields at all still parses, as nulls, not as a throw", async () => {
+    const client = createApiClient({
+      fetchImpl: async () =>
+        json({
+          ref: { owner: "acme", repo: "api", number: 7 },
+          pr: { author: "ada", headSha: "sha1" },
+          rounds: [
+            {
+              round: 1,
+              agent: "reviewer",
+              provider: "claude-cli",
+              status: "ok",
+              headSha: "sha1",
+              startedAt: "2026-08-30T00:00:00.000Z",
+              durationMs: 1000,
+              hasSnapshot: false,
+              findings: [],
+              // sessionId, sessionCwd, costUsd, turns, resumeCommand: absent
+              // entirely, as every round file written before they existed.
+            },
+          ],
+        }),
+      storage: memoryStorage(),
+      location: stubLocation("#t=tok"),
+      history: stubHistory(),
+    });
+
+    const res = await client.getFindings({ owner: "acme", repo: "api", number: 7 });
+
+    expect(res.rounds).toHaveLength(1);
+    expect(res.rounds[0]).toMatchObject({
+      round: 1,
+      agent: "reviewer",
+      sessionId: null,
+      sessionCwd: null,
+      costUsd: null,
+      turns: null,
+      resumeCommand: null,
+    });
   });
 });
 
@@ -778,5 +887,65 @@ describe("FindingCard (smoke)", () => {
       createElement(FindingCard, { owner: "acme", repo: "api", finding: baseFinding }),
     );
     expect(html).toMatch(/disabled[\s\S]*Discard/);
+  });
+});
+
+// ─── RoundSession (smoke) ────────────────────────────────────────────────────
+//
+// Rendered directly with a RoundSummary, the same way FindingCard is tested
+// above: PRDetail's own hook never resolves under renderToStaticMarkup (see
+// that describe block), so this is the only way to see the populated markup
+// rather than just the loading state.
+
+describe("RoundSession (smoke)", () => {
+  const baseRound: RoundSessionProps["round"] = {
+    round: 2,
+    agent: "reviewer",
+    provider: "claude-cli",
+    status: "ok",
+    headSha: "abc123",
+    startedAt: "2026-08-30T00:00:00.000Z",
+    durationMs: 45_000,
+    hasSnapshot: true,
+    sessionId: "sess-abc123",
+    sessionCwd: "/Users/ada/repos/api",
+    costUsd: 0.42,
+    turns: 7,
+    resumeCommand: "cd /Users/ada/repos/api && claude --resume sess-abc123",
+  };
+
+  test("renders the resume command as pasteable text, what it does, and the cost/turns as quiet metadata", () => {
+    const html = renderToStaticMarkup(createElement(RoundSession, { round: baseRound }));
+
+    // `&&` renders HTML-escaped (`&amp;&amp;`), so the two halves are checked
+    // separately rather than as one literal command string.
+    expect(html).toContain("cd /Users/ada/repos/api");
+    expect(html).toContain("claude --resume sess-abc123");
+    expect(html).toContain("Round 2");
+    expect(html).toContain("reviewer");
+    expect(html).toContain("Reopen the Claude session");
+    expect(html).toContain("$0.42");
+    expect(html).toContain("7 turns");
+    expect(html).toMatch(/Copy/);
+  });
+
+  test("a round with no session id renders nothing", () => {
+    const html = renderToStaticMarkup(
+      createElement(RoundSession, {
+        round: { ...baseRound, sessionId: null, sessionCwd: null, resumeCommand: null },
+      }),
+    );
+
+    expect(html).toBe("");
+  });
+
+  test("cost and turns are each optional and never invent the other", () => {
+    const html = renderToStaticMarkup(
+      createElement(RoundSession, { round: { ...baseRound, costUsd: null, turns: 1 } }),
+    );
+
+    expect(html).not.toContain("$0.42");
+    expect(html).toContain("1 turn");
+    expect(html).not.toContain("1 turns");
   });
 });

--- a/src/ui/views/PRDetail.tsx
+++ b/src/ui/views/PRDetail.tsx
@@ -3,11 +3,13 @@
  * UI", "PR detail"; this task's scope stops at the reading surface — the
  * post flow and its confirm pane are a separate task).
  */
+import { useState } from "react";
 import type { Classification, PRRef } from "@/core";
-import { REAUTH_MESSAGE, type FindingWithContext } from "@/ui/api";
+import { REAUTH_MESSAGE, type FindingWithContext, type RoundSummary } from "@/ui/api";
 import { usePRDetail } from "@/ui/hooks";
 import { FindingCard } from "@/ui/components/FindingCard";
 import { PostPane } from "@/ui/views/PostPane";
+import { Button } from "@/components/ui/button";
 
 export interface PRDetailProps {
   prRef: PRRef;
@@ -29,6 +31,78 @@ function ClassificationBadge({ classification }: { classification: Classificatio
     <span className="inline-flex items-center rounded-full border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
       {CLASSIFICATION_LABEL[classification]}
     </span>
+  );
+}
+
+/** Two decimals, except where two decimals would round a real cost to $0.00. */
+function formatUsd(value: number): string {
+  return `$${value >= 0.01 ? value.toFixed(2) : value.toFixed(4)}`;
+}
+
+/**
+ * A resume command the user can paste into a terminal. A browser cannot open
+ * one itself, so the honest affordance is copy-to-clipboard plus a line
+ * saying what the command does, not a button that pretends to run it.
+ */
+function CopyResumeCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function copy(): void {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }, () => {});
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <code className="flex-1 overflow-x-auto rounded-md border bg-muted/30 px-2 py-1 font-mono text-xs">
+        {command}
+      </code>
+      <Button type="button" variant="outline" size="sm" onClick={copy}>
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
+}
+
+export interface RoundSessionProps {
+  round: RoundSummary;
+}
+
+/**
+ * One round's resume affordance. Rendered only for a round that has a
+ * session to resume; a round with no session id contributes nothing here,
+ * so it renders exactly as it did before this existed.
+ *
+ * Exported and props-in like FindingCard, so ui.test.ts can render it with
+ * real content directly rather than through PRDetail's data-fetching hook,
+ * which never resolves under `renderToStaticMarkup` (see that file's smoke
+ * tests).
+ */
+export function RoundSession({ round }: RoundSessionProps) {
+  if (!round.resumeCommand) return null;
+
+  const spent: string[] = [];
+  if (round.costUsd !== null) spent.push(formatUsd(round.costUsd));
+  if (round.turns !== null) spent.push(`${round.turns} turn${round.turns === 1 ? "" : "s"}`);
+
+  return (
+    <div className="rounded-lg border bg-card p-3" data-testid="round-session">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-medium">
+          Round {round.round} · {round.agent}
+        </span>
+        {spent.length > 0 && <span className="text-xs text-muted-foreground">{spent.join(" · ")}</span>}
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Reopen the Claude session that produced this round, with its full context.
+      </p>
+      <div className="mt-2">
+        <CopyResumeCommand command={round.resumeCommand} />
+      </div>
+    </div>
   );
 }
 
@@ -69,7 +143,8 @@ export function PRDetail({ prRef, onBack }: PRDetailProps) {
     );
   }
 
-  const { meta, findings } = data;
+  const { meta, findings, rounds } = data;
+  const resumable = rounds.filter((round) => round.resumeCommand);
   const groups = groupByFile(findings);
   const shortSha = meta.headSha ? meta.headSha.slice(0, 12) : "unknown";
 
@@ -123,6 +198,17 @@ export function PRDetail({ prRef, onBack }: PRDetailProps) {
             </section>
           ))}
         </div>
+      )}
+
+      {resumable.length > 0 && (
+        <section className="space-y-3 border-t pt-6" aria-label="Review sessions">
+          <h2 className="text-sm font-medium text-foreground">Review sessions</h2>
+          <div className="space-y-2">
+            {resumable.map((round) => (
+              <RoundSession key={`${round.round}-${round.agent}`} round={round} />
+            ))}
+          </div>
+        </section>
       )}
 
       {findings.length > 0 && (

--- a/src/ui/views/Reviews.tsx
+++ b/src/ui/views/Reviews.tsx
@@ -59,9 +59,11 @@ import {
   type PRDecisionAction,
   type PRListFilter,
   type PRListItem,
+  type QuotaMode,
+  type StatusResponse,
 } from "@/ui/api";
 import { getDefaultGateActions, type GateActions } from "@/ui/actions";
-import { useConnectionStatus, useStatus, usePRList, type ConnectionStatus } from "@/ui/hooks";
+import { useConnectionStatus, useStatus, usePRList, useTick, type ConnectionStatus } from "@/ui/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -264,6 +266,164 @@ function SeverityCounts({ counts }: { counts: FindingCounts }) {
   );
 }
 
+// ─── Live review progress ───────────────────────────────────────────────────
+//
+// The one thing the old "reviewing now" text could not say: whether a round
+// that started twenty seconds ago is indistinguishable from one about to hit
+// its timeout, and which of the concurrency slots a given PR is actually in.
+// `reviewProgressFor` answers both from the status payload's `queue`
+// (api.ts's `toStatusResponse`), matched to a PR row by the `key` the daemon
+// already formats. It is never reassembled from `owner`/`repo`/`number`
+// here, which is exactly the kind of two-spellings drift this file's module
+// doc warns about.
+
+/** First 7 characters of a SHA, GitHub's own short-ref convention. Empty input reads as a dash, not as a blank that looks like a rendering bug. */
+export function shortSha(sha: string): string {
+  return sha ? sha.slice(0, 7) : "—";
+}
+
+/** Milliseconds since `startedAt`, floored at zero so clock skew or a malformed timestamp never prints a negative duration. */
+export function elapsedMs(startedAt: string, now: number): number {
+  const started = new Date(startedAt).getTime();
+  if (!Number.isFinite(started)) return 0;
+  return Math.max(0, now - started);
+}
+
+/** Renders as "45s" or "2m 14s", matching `formatAge`'s conversational register. Never a raw millisecond count. */
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
+export type TimeoutUrgency = "normal" | "near" | "over";
+
+/**
+ * Where a round sits against its ceiling. `near` starts at 80% of the
+ * timeout. The M0 spike measured 5m44s for a typical two-file PR (queue.ts's
+ * module doc), so a round already 8 minutes in against a 10-minute ceiling
+ * is unusual enough to flag before it actually times out, not only after.
+ */
+export function timeoutUrgency(elapsed: number, timeoutMs: number): TimeoutUrgency {
+  if (elapsed >= timeoutMs) return "over";
+  if (elapsed >= timeoutMs * 0.8) return "near";
+  return "normal";
+}
+
+/**
+ * The daemon's default per-round ceiling (requirements R3.3; @/provider's
+ * `DEFAULT_TIMEOUT_MINUTES`, not imported here to keep this browser bundle
+ * free of the Provider's own Node-side code). It is *not* part of the
+ * published `/api/status` contract. The configured value lives in a
+ * hand-edited `agents/<name>.md`, and today's status route does not carry
+ * it, so this is the best available reference point. It is exact for every
+ * install that has not overridden it, and still the right "this is
+ * unusually long" marker for the ones that have.
+ */
+export const DEFAULT_ROUND_TIMEOUT_MS = 10 * 60_000;
+
+export type ReviewProgress =
+  | { kind: "reviewing"; headSha: string; elapsedMs: number; timeoutMs: number; urgency: TimeoutUrgency }
+  | { kind: "queued"; headSha: string; position: number; total: number }
+  | { kind: "paused"; headSha: string; position: number; total: number; quotaMode: QuotaMode; quotaPercent: number | null }
+  // The PR row's own `state` says queued/reviewing, but the queue snapshot
+  // (a separate part of the same status payload, potentially a poll behind)
+  // has no matching entry. That is a brief race between two fetches, not a
+  // bug, and callers fall back to the old plain-text label for it.
+  | { kind: "unmatched" };
+
+export function reviewProgressFor(
+  pr: PRListItem,
+  status: StatusResponse,
+  now: number,
+  timeoutMs: number = DEFAULT_ROUND_TIMEOUT_MS,
+): ReviewProgress {
+  if (pr.state === "reviewing") {
+    const round = status.queue.inFlightRounds.find((r) => r.key === pr.key);
+    if (!round) return { kind: "unmatched" };
+    const elapsed = elapsedMs(round.startedAt, now);
+    return { kind: "reviewing", headSha: round.headSha, elapsedMs: elapsed, timeoutMs, urgency: timeoutUrgency(elapsed, timeoutMs) };
+  }
+
+  if (pr.state === "queued") {
+    const index = status.queue.queuedEntries.findIndex((e) => e.key === pr.key);
+    if (index === -1) return { kind: "unmatched" };
+    const entry = status.queue.queuedEntries[index]!;
+    const total = status.queue.queuedEntries.length;
+    if (status.queue.pausedByGate) {
+      return {
+        kind: "paused",
+        headSha: entry.headSha,
+        position: index + 1,
+        total,
+        quotaMode: status.quotaMode,
+        quotaPercent: status.quotaPercent,
+      };
+    }
+    return { kind: "queued", headSha: entry.headSha, position: index + 1, total };
+  }
+
+  return { kind: "unmatched" };
+}
+
+/** Why the gate is holding the queue, in the terms `pause_above_pct`/the daily-cap fallback actually use (daemon/quota.ts). */
+export function quotaReason(mode: QuotaMode, percent: number | null): string {
+  if (mode === "fallback") return "usage unreadable, gating on the daily cap";
+  if (mode === "throttled") return percent !== null ? `throttled at ${percent}%` : "throttled";
+  return "paused";
+}
+
+const URGENCY_TONE: Record<TimeoutUrgency, string> = {
+  normal: "text-muted-foreground",
+  near: "text-yellow-700 dark:text-yellow-400",
+  over: "text-destructive font-medium",
+};
+
+/**
+ * A static width, not an animated one. `prefers-reduced-motion` rules out
+ * transitions and pulsing. It does not rule out a number, or a bar snapped
+ * to a new width on every tick, actually changing value. That change is the
+ * elapsed time itself, the whole point of this row.
+ */
+function ReviewProgressLine({ progress }: { progress: ReviewProgress }) {
+  switch (progress.kind) {
+    case "reviewing": {
+      const tone = URGENCY_TONE[progress.urgency];
+      const pct = Math.min(100, Math.round((progress.elapsedMs / progress.timeoutMs) * 100));
+      const barTone = progress.urgency === "over" ? "bg-destructive" : progress.urgency === "near" ? "bg-yellow-500" : "bg-foreground/40";
+      return (
+        <span className="flex min-w-[12rem] flex-1 flex-col gap-1" data-testid="reviewing-progress">
+          <span className={`text-xs ${tone}`}>
+            reviewing @{shortSha(progress.headSha)} · {formatDuration(progress.elapsedMs)} of {formatDuration(progress.timeoutMs)}
+            {progress.urgency === "near" && ", approaching the timeout"}
+            {progress.urgency === "over" && ", past the timeout, still running"}
+          </span>
+          <span className="h-1 w-full max-w-40 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+            <span className={`block h-full rounded-full ${barTone}`} style={{ width: `${pct}%` }} />
+          </span>
+        </span>
+      );
+    }
+    case "queued":
+      return (
+        <span className="text-xs text-muted-foreground" data-testid="queued-progress">
+          queued @{shortSha(progress.headSha)} ·{" "}
+          {progress.position === 1 ? "next in line" : `${progress.position - 1} ahead in the queue`}
+        </span>
+      );
+    case "paused":
+      return (
+        <span className="text-xs font-medium text-yellow-700 dark:text-yellow-400" data-testid="paused-progress">
+          held by the quota gate ({quotaReason(progress.quotaMode, progress.quotaPercent)}) · queued @{shortSha(progress.headSha)}
+          {progress.total > 1 ? `, position ${progress.position} of ${progress.total}` : ""}
+        </span>
+      );
+    case "unmatched":
+      return null;
+  }
+}
+
 // ─── Rows ───────────────────────────────────────────────────────────────────
 
 /**
@@ -405,9 +565,21 @@ function reviewStateLabel(pr: PRListItem): string {
   return pr.failedAttempts >= 3 ? "failed, no retries left" : "failed, will retry";
 }
 
-function InReviewRow({ pr, onOpenPR }: { pr: PRListItem; onOpenPR?: (ref: PRRef) => void }) {
+function InReviewRow({
+  pr,
+  status,
+  now,
+  onOpenPR,
+}: {
+  pr: PRListItem;
+  /** Null while the status poll is still loading; that PR's row falls back to the plain-text label rather than waiting. */
+  status: StatusResponse | null;
+  now: number;
+  onOpenPR?: (ref: PRRef) => void;
+}) {
   const stuck = pr.state === "failed" && pr.failedAttempts >= 3;
   const hasFindings = totalFindings(pr.findingCounts) > 0;
+  const progress = status ? reviewProgressFor(pr, status, now) : { kind: "unmatched" as const };
 
   return (
     <div className="flex items-center justify-between gap-4 border-b py-3 last:border-b-0" data-testid="in-review-row">
@@ -419,9 +591,13 @@ function InReviewRow({ pr, onOpenPR }: { pr: PRListItem; onOpenPR?: (ref: PRRef)
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
           <PRIdentity pr={pr} />
           <span className="text-xs text-muted-foreground">@{pr.author}</span>
-          <span className={stuck ? "text-xs font-medium text-destructive" : "text-xs text-muted-foreground"}>
-            {reviewStateLabel(pr)}
-          </span>
+          {progress.kind === "unmatched" ? (
+            <span className={stuck ? "text-xs font-medium text-destructive" : "text-xs text-muted-foreground"}>
+              {reviewStateLabel(pr)}
+            </span>
+          ) : (
+            <ReviewProgressLine progress={progress} />
+          )}
           {/* An earlier round's findings are still gateable while a new one runs. */}
           {hasFindings && <SeverityCounts counts={pr.findingCounts} />}
         </div>
@@ -539,7 +715,19 @@ export function SkippedRow({ pr, actions }: { pr: PRListItem; actions?: GateActi
 
 
 /** Dispatch a row to the renderer its state calls for. */
-function ReviewRow({ pr, onOpenPR, actions }: { pr: PRListItem; onOpenPR?: (ref: PRRef) => void; actions?: GateActions }) {
+function ReviewRow({
+  pr,
+  onOpenPR,
+  actions,
+  status,
+  now,
+}: {
+  pr: PRListItem;
+  onOpenPR?: (ref: PRRef) => void;
+  actions?: GateActions;
+  status: StatusResponse | null;
+  now: number;
+}) {
   switch (pr.state) {
     case "triage":
       return <TriageRow pr={pr} actions={actions} />;
@@ -548,7 +736,7 @@ function ReviewRow({ pr, onOpenPR, actions }: { pr: PRListItem; onOpenPR?: (ref:
     case "queued":
     case "reviewing":
     case "failed":
-      return <InReviewRow pr={pr} onOpenPR={onOpenPR} />;
+      return <InReviewRow pr={pr} status={status} now={now} onOpenPR={onOpenPR} />;
     case "reviewed":
       return <ReviewedRow pr={pr} onOpenPR={onOpenPR} />;
     case "closed":
@@ -652,6 +840,17 @@ export function Reviews({ onOpenPR, actions }: ReviewsProps) {
   // forbid skipping one), and it stays a real server request either way,
   // never a client-side re-filter of `mainList`'s rows.
   const countsList = usePRList(filterToQuery("all", closedFilter));
+  // The queue/quota detail behind every in-flight and queued row below.
+  // Same duplication trade-off as `countsList`. `EmptyPanel` also calls
+  // `useStatus()`, on its own poll cycle, but only one of the two is ever
+  // mounted at a time (this list is either empty or it isn't).
+  const statusQuery = useStatus();
+  const liveRows = mainList.data ?? [];
+  const hasLiveRows = liveRows.some((pr) => pr.state === "reviewing" || pr.state === "queued");
+  // Ticks once a second, but only while something is actually in flight or
+  // queued. A fully reviewed/closed list has nothing whose elapsed time
+  // needs to advance, so nothing here re-renders for no reason.
+  const now = useTick(1000, hasLiveRows);
 
   if (mainList.error?.kind === "unauthenticated") {
     return (
@@ -661,7 +860,7 @@ export function Reviews({ onOpenPR, actions }: ReviewsProps) {
     );
   }
 
-  const rows = mainList.data ?? [];
+  const rows = liveRows;
   // The one client-side split left: pulling the collapsed skipped section
   // back out of an "all" response the server already filtered correctly.
   // Selecting "Skipped" directly bypasses this — that is the filter's own
@@ -695,7 +894,14 @@ export function Reviews({ onOpenPR, actions }: ReviewsProps) {
             <Card>
               <CardContent className="pt-6">
                 {visibleRows.map((pr) => (
-                  <ReviewRow key={`${pr.owner}/${pr.repo}#${pr.number}`} pr={pr} onOpenPR={onOpenPR} actions={actions} />
+                  <ReviewRow
+                    key={`${pr.owner}/${pr.repo}#${pr.number}`}
+                    pr={pr}
+                    onOpenPR={onOpenPR}
+                    actions={actions}
+                    status={statusQuery.data ?? null}
+                    now={now}
+                  />
                 ))}
               </CardContent>
             </Card>

--- a/test/fixtures/fake-claude.ts
+++ b/test/fixtures/fake-claude.ts
@@ -8,7 +8,19 @@
  *
  * Invoked as: claude -p <prompt> --output-format json --model <m>
  * (other flags are accepted but ignored)
+ *
+ * The envelope carries the session fields the real CLI reports beside the
+ * review text: session_id, total_cost_usd and num_turns. They are fixed
+ * values, so a test can assert on them, and they are what lets the provider's
+ * session capture be exercised without spawning the real binary.
  */
+
+/** The session fields the real CLI reports alongside its result. */
+const SESSION = {
+  session_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  total_cost_usd: 0.77,
+  num_turns: 14,
+};
 
 function fail(message: string, exitCode = 1): never {
   console.error(message);
@@ -44,6 +56,7 @@ function emitJsonMode(): void {
     type: "result",
     subtype: "success",
     is_error: false,
+    ...SESSION,
     result: JSON.stringify({ findings }),
   };
 
@@ -60,6 +73,7 @@ function emitProseMode(): void {
     type: "result",
     subtype: "success",
     is_error: false,
+    ...SESSION,
     result: findings.join("\n"),
   };
 
@@ -75,6 +89,7 @@ function emitEmptyMode(): void {
     type: "result",
     subtype: "success",
     is_error: false,
+    ...SESSION,
     result: JSON.stringify({ findings: [] }),
   };
 


### PR DESCRIPTION
Three changes, one per commit, plus the documentation refresh that landed while these were being built.

## Open the session that produced a finding

The CLI's envelope carries a `session_id` and LGTM was discarding it. Print-mode sessions persist, and `claude --resume` genuinely restores one: resuming a review from hours earlier, it described the PR it had reviewed without being told. So a finding stops being a verdict and becomes something you can argue with, ask to explain itself, or ask for the fix.

Rounds now record `sessionId`, `sessionCwd`, `costUsd` and `turns`, and the PR detail view offers the command that reopens the session. A browser cannot open a terminal and does not pretend to, so it is copy-to-clipboard, with the `cd` inside the command because a resume from the wrong directory finds nothing.

Reviews also spawn from a directory the daemon owns now. Until this, `cwd` was an option on the spawn that nobody passed, so a review ran from wherever `lgtm up` happened to start and its session landed in an unpredictable slug.

## See how far along a running review is

Six minutes is a long time to look at the words "reviewing now". A row now shows elapsed against the timeout with a bar that escalates as it approaches, the head SHA, and a queue position for PRs that are waiting. When the quota gate is holding work back the row says so with the mode and percentage, because a deliberate pause and a stall look identical otherwise.

All of this was already on `/api/status`. None of it reached the browser: the client's status parser collapsed the entire queue object into one number.

## Two things left off on purpose

The daemon does not publish which agent is running a round (the queue marks it in flight before the agent is resolved) or the agent's configured timeout, so the shared ten-minute default stands in. Both are absences in the wire contract rather than parser bugs, and neither was worth guessing at in the browser.

## Checks

1206 tests, typecheck clean, binary builds. Each change was mutation-checked rather than assumed: dropping `resumeCommand` from the route fails the contract test, and matching status rows by array position instead of by key fails a test written for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)